### PR TITLE
Simulation texture replaced by renderer-compatible raw buffer

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -449,7 +449,7 @@ private:
         parameter --report)
         @return the number of simulation frames loaded
     */
-    size_t _loadCompartmentReport()
+    void _loadCompartmentReport()
     {
         GeometryParameters& geometryParameters =
             _parametersManager->getGeometryParameters();
@@ -463,8 +463,8 @@ private:
             filename << std::endl;
         MorphologyLoader morphologyLoader( geometryParameters );
         const servus::URI uri( filename );
-        return morphologyLoader.importSimulationIntoTexture(
-            uri, target, report, *_engine->getScene());
+        if( morphologyLoader.importSimulationData( uri, target, report, *_engine->getScene()))
+            _engine->getScene()->commitSimulationData();
     }
 
     void _buildDefaultScene()

--- a/brayns/common/log.h
+++ b/brayns/common/log.h
@@ -22,6 +22,7 @@
 #define BRAYNS_LOG_H
 
 #include <iostream>
+#include <mutex>
 #define BRAYNS_ERROR std::cerr << "[ERROR] "
 #define BRAYNS_WARN std::cerr << "[WARN ] "
 #define BRAYNS_INFO std::cout << "[INFO ] "
@@ -36,5 +37,20 @@
         BRAYNS_ERROR << exc.what() << std::endl;\
         throw exc;\
     }
+
+static std::mutex __logging_mtx;
+#define BRAYNS_PROGRESS( __value, __maxValue ) \
+{\
+    __logging_mtx.lock();\
+    std::cout << "[";\
+    size_t __percent = 100 * ( __value + 1 ) / __maxValue;\
+    for( size_t __progress = 0; __progress < 100; ++__progress )\
+        std::cout << ( __progress <= __percent ? "=" : " " );\
+    std::cout << "] " << int( __percent ) << " %\r";\
+    std::cout.flush();\
+    if( __value >= __maxValue - 1 )\
+        std::cout << std::endl;\
+    __logging_mtx.unlock();\
+}
 
 #endif

--- a/brayns/common/scene/Scene.cpp
+++ b/brayns/common/scene/Scene.cpp
@@ -58,12 +58,9 @@ void Scene::setMaterials(
     {
         MaterialPtr material( new Material );
 
-        // Special materials (Simulation, skybox, etc)
+        // Special materials ( skybox, etc )
         switch( i )
         {
-            case MATERIAL_SIMULATION:
-                material->setTexture( TT_DIFFUSE, TEXTURE_NAME_SIMULATION );
-                break;
             case MATERIAL_BOUNDING_BOX:
                 material->setColor( Vector3f( 1.f, 1.f, 1.f ));
                 material->setEmission( 1.f );

--- a/brayns/common/scene/Scene.h
+++ b/brayns/common/scene/Scene.h
@@ -100,6 +100,11 @@ public:
     BRAYNS_API virtual void buildGeometry() = 0;
 
     /**
+        Attach simulation data to renderer
+    */
+    BRAYNS_API virtual void commitSimulationData() = 0;
+
+    /**
         Returns the bounding box for the whole scene
     */
     Boxf& getWorldBounds() { return _bounds; }
@@ -152,6 +157,8 @@ public:
     BRAYNS_API TexturesMap& getTextures() { return _textures; }
     BRAYNS_API TrianglesMeshMap& getTriangleMeshes() { return _trianglesMeshes; }
 
+    BRAYNS_API SimulationData& getSimulationData() { return _simulationData; }
+
 protected:
     // Parameters
     SceneParameters& _sceneParameters;
@@ -164,6 +171,9 @@ protected:
     Materials _materials;
     TexturesMap _textures;
     Lights _lights;
+
+    // Simulation
+    SimulationData _simulationData;
 
     Boxf _bounds;
     bool _isEmpty;

--- a/brayns/common/types.h
+++ b/brayns/common/types.h
@@ -211,16 +211,21 @@ struct ExtensionParameters
     EnginePtr engine;
 };
 
+/** Extension parameters */
+struct SimulationData
+{
+    std::map< uint64_t, floats > valuesPerFrame;
+};
+
 /** Some 'special' materials are used by Brayns to acomplish specific features
- *  such as simulations, or skyboxes.
+ *  such as skyboxes.
  */
 const size_t NO_MATERIAL = -1;
 const size_t NB_MAX_MATERIALS = 200;
 const size_t NB_SYSTEM_MATERIALS = 3;
 const size_t MATERIAL_SYSTEM = NB_MAX_MATERIALS - NB_SYSTEM_MATERIALS;
 const size_t MATERIAL_SKYBOX = MATERIAL_SYSTEM + 0;
-const size_t MATERIAL_SIMULATION = MATERIAL_SYSTEM + 1;
-const size_t MATERIAL_BOUNDING_BOX = MATERIAL_SYSTEM + 2;
+const size_t MATERIAL_BOUNDING_BOX = MATERIAL_SYSTEM + 1;
 const std::string TEXTURE_NAME_SKYBOX = "SKYBOX";
 const std::string TEXTURE_NAME_SIMULATION = "SIMULATION";
 

--- a/brayns/io/MorphologyLoader.h
+++ b/brayns/io/MorphologyLoader.h
@@ -37,7 +37,7 @@ namespace brayns
  * comparmentCounts: Number of compartments per section
  * comparmentOffsets: Offset for every compartments
  */
-struct SimulationData
+struct SimulationInformation
 {
     const uint16_ts* compartmentCounts;
     const uint64_ts* compartmentOffsets;
@@ -96,21 +96,16 @@ public:
         const std::string& target,
         Scene& scene);
 
-    /** Imports simulation data into a texture. Each frame of the simulation
-     *  is a line of the texture, and simulation values are stored in columns.
-     *  In the current implementation, RGB values are all equal to the
-     *  normalized value of the data againt the whole simulation. In future
-     *  work, R, G and B can be used to store different pieces of information
-     *  that can then be interpreted by simulation renderer.
+    /** Imports simulation data into the scene
      * @param circuitConfig URI of the Circuit Config file
      * @param target Target to be loaded. If empty, the target specified in the
      *        circuit configuration file is used. If such an entry does not
      *        exist, all neurons are loaded.
      * @param report report to be loaded.
      * @param scene resulting scene
-     * @return The number of loaded frames.
+     * @return True if simulation was successfully loaded, dalse otherwise
      */
-    size_t importSimulationIntoTexture(
+    bool importSimulationData(
         const servus::URI& circuitConfig,
         const std::string& target,
         const std::string& report,
@@ -121,7 +116,7 @@ private:
         const servus::URI& source,
         size_t morphologyIndex,
         const Matrix4f& transformation,
-        const SimulationData* simulationData,
+        const SimulationInformation* simulationInformation,
         PrimitivesMap& primitives,
         Boxf& bounds,
         const size_t simulationOffset,

--- a/brayns/parameters/GeometryParameters.h
+++ b/brayns/parameters/GeometryParameters.h
@@ -127,11 +127,11 @@ public:
     /** Defines if cells with no simulation data should be loaded */
     size_t getNonSimulatedCells() const { return _nonSimulatedCells; }
 
-    /** Defines the range of frames to be loaded for the simulation
-        This is related to the current size of the texture that is limited to
-        2 GB. This of course needs to be improved! */
-    size_t getLastSimulationFrame() const { return _lastSimulationFrame; }
-    size_t getFirstSimulationFrame() const { return _firstSimulationFrame; }
+    /** Defines the range of frames to be loaded for the simulation */
+    float getEndSimulationTime() const { return _endSimulationTime; }
+    float getStartSimulationTime() const { return _startSimulationTime; }
+
+    Vector2f getSimulationValuesRange() const { return _simulationValuesRange; }
 
     /** Defines if multiple models should be generated to increase the
         rendering performance */
@@ -158,8 +158,9 @@ protected:
     size_t _morphologySectionTypes;
     MorphologyLayout _morphologyLayout;
     size_t _nonSimulatedCells;
-    size_t _firstSimulationFrame;
-    size_t _lastSimulationFrame;
+    float _startSimulationTime;
+    float _endSimulationTime;
+    Vector2f _simulationValuesRange;
     bool _generateMultipleModels;
 };
 

--- a/plugins/engines/ospray/OSPRayEngine.cpp
+++ b/plugins/engines/ospray/OSPRayEngine.cpp
@@ -98,6 +98,7 @@ void OSPRayEngine::commit()
 
 void OSPRayEngine::render()
 {
+    _scene->commitSimulationData();
     _renderers[_activeRenderer]->render( _frameBuffer );
 }
 

--- a/plugins/engines/ospray/geometry/ExtendedCones.ispc
+++ b/plugins/engines/ospray/geometry/ExtendedCones.ispc
@@ -233,11 +233,8 @@ static void ExtendedCones_postIntersect(uniform Geometry *uniform geometry,
 
     uniform uint8 *conePtr =
             THIS->data + THIS->bytesPerCone*ray.primID;
-    // Store timestamp as texture coordinate
-    varying float value =
-            *((varying float *)(conePtr+THIS->offset_value));
-    dg.st.x = value;
-
+    // Store value as texture coordinate
+    dg.st.x = *((varying float *)(conePtr+THIS->offset_value));
 
     if (flags & DG_NORMALIZE)\
     {

--- a/plugins/engines/ospray/geometry/ExtendedCylinders.ispc
+++ b/plugins/engines/ospray/geometry/ExtendedCylinders.ispc
@@ -155,10 +155,8 @@ static void ExtendedCylinders_postIntersect(uniform Geometry *uniform geometry,
 
     uniform uint8 *cylinderPtr =
             THIS->data + THIS->bytesPerCylinder*ray.primID;
-    // Store timestamp as texture coordinate
-    varying float value =
-            *((varying float *)(cylinderPtr+THIS->offset_value));
-    dg.st.x = value;
+    // Store value as texture coordinate
+    dg.st.x = *((varying float *)(cylinderPtr+THIS->offset_value));
 
     if (flags & DG_NORMALIZE)
     {

--- a/plugins/engines/ospray/geometry/ExtendedSpheres.ispc
+++ b/plugins/engines/ospray/geometry/ExtendedSpheres.ispc
@@ -69,9 +69,7 @@ static void ExtendedSpheres_postIntersect(uniform Geometry *uniform geometry,
     // Store timestamp as texture coordinate
     uniform uint8 *spherePtr =
             THIS->data + THIS->bytesPerExtendedSphere*ray.primID;
-    varying float value =
-        *((varying float *)(spherePtr+THIS->offset_value));
-    dg.st.x = value;
+    dg.st.x = *((varying float *)(spherePtr+THIS->offset_value));
 
     if (flags & DG_NORMALIZE)
     {
@@ -105,10 +103,8 @@ static void ExtendedSpheres_postIntersect(uniform Geometry *uniform geometry,
                 if (THIS->materialList)
                     dg.material = THIS->materialList[dg.materialID];
 
-                // Store timestamp as texture coordinate
-                varying float value =
-                    *((varying float *)(spherePtr+THIS->offset_value));
-                dg.st.x = value;
+                // Store value as texture coordinate
+                dg.st.x = *((varying float *)(spherePtr+THIS->offset_value));
             }
         }
         else

--- a/plugins/engines/ospray/render/OSPRayScene.h
+++ b/plugins/engines/ospray/render/OSPRayScene.h
@@ -42,6 +42,7 @@ public:
     void buildGeometry() final;
     void commitLights() final;
     void commitMaterials( const bool updateOnly = false ) final;
+    void commitSimulationData() final;
 
     OSPModel* modelImpl( const size_t timestamp );
 
@@ -60,6 +61,7 @@ private:
     std::vector< OSPLight > _ospLights;
     OSPData _ospLightData;
     OSPData _ospMaterialData;
+    OSPData _ospSimulationData;
 
     std::map< float, size_t > _timestamps;
 

--- a/plugins/engines/ospray/render/SimulationRenderer.cpp
+++ b/plugins/engines/ospray/render/SimulationRenderer.cpp
@@ -22,6 +22,9 @@
 
 #include <plugins/engines/ospray/render/SimulationRenderer.h>
 
+// ospray
+#include <ospray/common/Data.h>
+
 // ispc exports
 #include "SimulationRenderer_ispc.h"
 
@@ -30,15 +33,14 @@ using namespace ospray;
 namespace brayns
 {
 
-void SimulationRenderer::commit( )
+void SimulationRenderer::commit()
 {
     AbstractRenderer::commit();
 
-    _simulationNbOffsets = getParam1i( "simulationNbOffsets", 0 );
-    _simulationNbFrames = getParam1i( "simulationNbFrames", 0 );
+    _simulationData = getParamData("simulationData" );
 
     ispc::SimulationRenderer_set(
-                getIE( ),
+                getIE(),
                 ( ispc::vec3f& )_bgColor,
                 _shadowsEnabled,
                 _softShadowsEnabled,
@@ -48,10 +50,9 @@ void SimulationRenderer::commit( )
                 _timestamp,
                 _spp,
                 _electronShadingEnabled,
-                _simulationNbOffsets,
-                _simulationNbFrames,
-                _lightPtr, _lightArray.size( ),
-                _materialPtr, _materialArray.size( ));
+                _lightPtr, _lightArray.size(),
+                _materialPtr, _materialArray.size(),
+                _simulationData?( float* )_simulationData->data:NULL );
 }
 
 SimulationRenderer::SimulationRenderer( )

--- a/plugins/engines/ospray/render/SimulationRenderer.h
+++ b/plugins/engines/ospray/render/SimulationRenderer.h
@@ -47,8 +47,10 @@ public:
 
 private:
 
-    int _simulationNbOffsets;
-    int _simulationNbFrames;
+    ospray::Ref< ospray::Data > _simulationData;
+
+    ospray::int64 _simulationFrameSize;
+    ospray::int64 _simulationNbFrames;
 };
 
 } // ::brayns

--- a/plugins/engines/ospray/render/SimulationRenderer.ispc
+++ b/plugins/engines/ospray/render/SimulationRenderer.ispc
@@ -23,38 +23,30 @@
 // Brayns
 #include <plugins/engines/ospray/render/utils/AbstractRenderer.ih>
 
-#define DEFAULT_LIGHT_EMISSION_MULTIPLIER 10.f
+#define DEFAULT_LIGHT_EMISSION_MULTIPLIER 1.f
 
 struct SimulationRenderer
 {
     AbstractRenderer abstract;
 
-    int simulationNbOffsets;
-    int simulationNbFrames;
+    uniform float* uniform simulationData;
+    uint64 simulationFrameSize;
+    uint64 simulationNbFrames;
 };
 
-inline varying vec3f getSimulationValue(
+inline varying float getSimulationValue(
     const uniform SimulationRenderer* uniform self,
     DifferentialGeometry& dg)
 {
-    // Get simulation value from geometry timestamp and material 0
-    varying vec3f simulationValue = make_vec3f(0.f);
-    if( dg.st.x < 0.f )
-        return simulationValue;
+    if( !self->simulationData )
+        return 0.f;
 
-    const uniform ExtendedOBJMaterial *uniform mat =
-        self->abstract.materials[MATERIAL_SIMULATION];
-    if( mat->map_Kd )
-    {
-        const varying vec2f st =
-        {
-            dg.st.x / (float)self->simulationNbOffsets,
-            ((int)self->abstract.timestamp % self->simulationNbFrames) /
-                (float)self->simulationNbFrames
-        };
-        simulationValue = get3f(mat->map_Kd, st);
-    }
-    return simulationValue;
+    const varying float value = self->simulationData[ dg.st.x ];
+    if( value < DEFAULT_LIGHT_THRESHOLD )
+        return 0.f;
+
+    return DEFAULT_LIGHT_EMISSION_MULTIPLIER * value;
+
 }
 
 inline vec3f SimulationRenderer_shadeRay(
@@ -114,8 +106,8 @@ inline vec3f SimulationRenderer_shadeRay(
             varying float localLightIntensity = 1.f;
 
             // Get simulation value from geometry ID
-            const varying vec3f simulationValue = getSimulationValue( self, dg );
-            localLightEmission = DEFAULT_LIGHT_EMISSION_MULTIPLIER * simulationValue.x;
+            const float simulationValue = getSimulationValue( self, dg );
+            localLightEmission = simulationValue;
 
             // Process material attributes
             const uniform Material* material = dg.material;
@@ -210,9 +202,8 @@ inline vec3f SimulationRenderer_shadeRay(
                         indirectShadingColor = indirectShadingColor * localOpacity;
 
                         // Get simulation value from geometry ID
-                        const varying vec3f simulationValue = getSimulationValue( self, geometry );
-                        indirectShadingIntensity +=
-                            DEFAULT_LIGHT_EMISSION_MULTIPLIER * simulationValue.x;
+                        const float simulationValue = getSimulationValue( self, geometry );
+                        indirectShadingIntensity += simulationValue;
                     }
                 }
 
@@ -227,10 +218,8 @@ inline vec3f SimulationRenderer_shadeRay(
                 {
                     // Electron Shading
                     localLightIntensity = 1.f;
-                    const varying vec3f viewer =
-                        normalize( ray.org - intersection );
-                    const varying float el =
-                        max( 0.f, dot( viewer, localNormal ));
+                    const varying vec3f viewer = normalize( ray.org - intersection );
+                    const varying float el = max( 0.f, dot( viewer, localNormal ));
                     varying float cosNL  = localLightEmission + ( 0.1f - 0.1f * el );
                     localShadedColor =
                         localOpacity * cosNL *
@@ -333,7 +322,7 @@ inline vec3f SimulationRenderer_shadeRay(
 
     // Back to front computation of final color according to colors and weights of each ray
     // generation
-    sample.alpha =  pathOpacity;
+    sample.alpha = pathOpacity;
     for( int i = depth - 2; i >= 0; --i )
         intersectionColors[i] =
             intersectionColors[i+1] * intersectionWeights[i] +
@@ -374,15 +363,13 @@ export void SimulationRenderer_set(
         const uniform float& timestamp,
         const uniform int& spp,
         const uniform bool& electronShadingEnabled,
-        const uniform int& simulationNbOffsets,
-        const uniform int& simulationNbFrames,
         void** uniform lights,
-        uniform int32 numLights,
+        const uniform int32 numLights,
         void** uniform materials,
-        uniform int32 numMaterials )
+        const uniform int32 numMaterials,
+        uniform float* uniform simulationData )
 {
-    uniform SimulationRenderer* uniform self =
-            ( uniform SimulationRenderer* uniform )_self;
+    uniform SimulationRenderer* uniform self = ( uniform SimulationRenderer* uniform )_self;
 
     self->abstract.bgColor = bgColor;
     self->abstract.shadowsEnabled = shadowsEnabled;
@@ -394,14 +381,12 @@ export void SimulationRenderer_set(
     self->abstract.spp = spp;
     self->abstract.electronShadingEnabled = electronShadingEnabled;
 
-    self->abstract.lights =
-        ( const uniform Light* uniform* uniform )lights;
+    self->abstract.lights = ( const uniform Light* uniform* uniform )lights;
     self->abstract.numLights = numLights;
 
-    self->abstract.materials =
-        ( const uniform ExtendedOBJMaterial* uniform* uniform )materials;
+    self->abstract.materials = ( const uniform ExtendedOBJMaterial* uniform* uniform )materials;
     self->abstract.numMaterials = numMaterials;
 
-    self->simulationNbOffsets = simulationNbOffsets;
-    self->simulationNbFrames = simulationNbFrames;
+    self->simulationData = (uniform float* uniform)simulationData;
+
 }

--- a/tests/brayns.cpp
+++ b/tests/brayns.cpp
@@ -112,8 +112,10 @@ BOOST_AUTO_TEST_CASE( defaults )
     BOOST_CHECK_EQUAL( geomParams.getMorphologySectionTypes(), brayns::MST_ALL );
     BOOST_CHECK_EQUAL( geomParams.getMorphologyLayout().type, brayns::ML_NONE );
     BOOST_CHECK_EQUAL( geomParams.getNonSimulatedCells(), 0 );
-    BOOST_CHECK_EQUAL( geomParams.getLastSimulationFrame(), 0 );
-    BOOST_CHECK_EQUAL( geomParams.getFirstSimulationFrame(), 0 );
+    BOOST_CHECK_EQUAL( geomParams.getStartSimulationTime(), 0.f );
+    BOOST_CHECK_EQUAL( geomParams.getEndSimulationTime(), std::numeric_limits< float >::max() );
+    BOOST_CHECK_EQUAL( geomParams.getSimulationValuesRange().x(), std::numeric_limits< float >::max() );
+    BOOST_CHECK_EQUAL( geomParams.getSimulationValuesRange().y(), std::numeric_limits< float >::min() );
 
     const auto& sceneParams = pm.getSceneParameters();
     BOOST_CHECK_EQUAL( sceneParams.getTimestamp(),


### PR DESCRIPTION
This now allows the full simulation to be loaded by removing the 4GB texture size limitation.