### PR TITLE
Fixed empty frames blinking while playbacking simulation in async mode

### DIFF
--- a/brayns/io/simulation/CircuitSimulationHandler.cpp
+++ b/brayns/io/simulation/CircuitSimulationHandler.cpp
@@ -98,7 +98,6 @@ void CircuitSimulationHandler::_triggerLoading(const uint32_t frame)
 
     _ready = false;
     _currentFrameFuture = _compartmentReport->loadFrame(timestamp);
-    _frameValues.reset();
 }
 
 bool CircuitSimulationHandler::_isFrameLoaded() const


### PR DESCRIPTION
The buffer is shared with OSPRay, so under no circumstances this shall
be reset() unless we assign a new buffer.