### PR TITLE
Detection distance to simulation model is now configurable

### DIFF
--- a/plugins/engines/ospray/ispc/render/SimulationRenderer.cpp
+++ b/plugins/engines/ospray/ispc/render/SimulationRenderer.cpp
@@ -54,6 +54,7 @@ void SimulationRenderer::commit()
     _transferFunctionMinValue = getParam1f("transferFunctionMinValue", 0.f);
     _transferFunctionRange = getParam1f("transferFunctionRange", 0.f);
     _threshold = getParam1f("threshold", _transferFunctionMinValue);
+    _detectionDistance = getParam1f("detectionDistance", 15.f);
 
     ispc::SimulationRenderer_set(
         getIE(), (_simulationModel ? _simulationModel->getIE() : nullptr),
@@ -73,7 +74,7 @@ void SimulationRenderer::commit()
             ? (ispc::vec3f*)_transferFunctionEmissionData->data
             : NULL,
         _transferFunctionSize, _transferFunctionMinValue,
-        _transferFunctionRange, _threshold);
+        _transferFunctionRange, _threshold, _detectionDistance);
 }
 
 SimulationRenderer::SimulationRenderer()

--- a/plugins/engines/ospray/ispc/render/SimulationRenderer.h
+++ b/plugins/engines/ospray/ispc/render/SimulationRenderer.h
@@ -55,6 +55,7 @@ private:
     ospray::vec3f _volumeOffset;
     float _volumeEpsilon;
     ospray::int32 _volumeSamplesPerRay;
+    float _detectionDistance;
 };
 
 } // ::brayns

--- a/plugins/engines/ospray/ispc/render/SimulationRenderer.ispc
+++ b/plugins/engines/ospray/ispc/render/SimulationRenderer.ispc
@@ -34,6 +34,7 @@ struct SimulationRenderer
     uniform float* uniform simulationData;
     uint64 simulationDataSize;
     float threshold;
+    float detectionDistance;
 };
 
 /**
@@ -101,7 +102,7 @@ inline void getValueFromSimulationModel(
     colorRay.dir = getRandomVector(sample, normal, self->abstract.randomNumber);
     colorRay.t0 = 0.f;
     colorRay.time = infinity;
-    colorRay.t = infinity;
+    colorRay.t = self->detectionDistance;
     colorRay.primID = -1;
     colorRay.geomID = -1;
     colorRay.instID = -1;
@@ -581,7 +582,8 @@ export void SimulationRenderer_set(
     const uniform uint64& simulationDataSize, uniform vec4f* uniform colormap,
     uniform vec3f* uniform emissionIntensitiesMap,
     const uniform int32 colorMapSize, const uniform float& colorMapMinValue,
-    const uniform float& colorMapRange, const uniform float& threshold)
+    const uniform float& colorMapRange, const uniform float& threshold,
+    const uniform float& detectionDistance)
 {
     uniform SimulationRenderer* uniform self =
         (uniform SimulationRenderer * uniform)_self;
@@ -626,4 +628,5 @@ export void SimulationRenderer_set(
     self->simulationDataSize = simulationDataSize;
 
     self->threshold = threshold;
+    self->detectionDistance = detectionDistance;
 }


### PR DESCRIPTION
The distance between the surface and the simulation model can be set using the detection-distance command line argument.