### PR TITLE
Enh/docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,14 +98,15 @@ RUN cksum ${BRAYNS_SRC}/.gitsubprojects && \
     freeglut3-dev \
     libassimp-dev \
     libboost-all-dev \
+    libglew-dev \
     libglu1-mesa-dev \
     libhdf5-serial-dev \
     libjpeg-turbo8-dev \
     libmagick++-dev \
     libturbojpeg \
     libxi-dev \
-    libzmq3-dev \
     libxmu-dev \
+    libzmq3-dev \
     python-pyparsing \
     qtbase5-dev \
     qtdeclarative5-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ ENV ISPC_VERSION 1.9.1
 ENV ISPC_DIR ispc-v${ISPC_VERSION}-linux
 ENV ISPC_PATH /app/$ISPC_DIR
 
-RUN mkdir -p ${ISPC_PATH} && \
-    apt-get update && \
-    apt-get -y install wget && \
-    wget http://netix.dl.sourceforge.net/project/ispcmirror/v${ISPC_VERSION}/${ISPC_DIR}.tar.gz && \
-    tar zxvf ${ISPC_DIR}.tar.gz -C ${ISPC_PATH} --strip-components=1 && \
-    rm $ISPC_DIR.tar.gz && \
-    apt-get -y remove wget && \
-    apt-get -y autoremove && \
-    apt-get clean
+RUN mkdir -p ${ISPC_PATH} \
+ && apt-get update \
+ && apt-get -y install wget \
+ && wget http://netix.dl.sourceforge.net/project/ispcmirror/v${ISPC_VERSION}/${ISPC_DIR}.tar.gz \
+ && tar zxvf ${ISPC_DIR}.tar.gz -C ${ISPC_PATH} --strip-components=1 \
+ && rm $ISPC_DIR.tar.gz \
+ && apt-get -y remove wget \
+ && apt-get -y autoremove \
+ && apt-get clean
 
 # Add ispc bin to the PATH
 ENV PATH $PATH:${ISPC_PATH}
@@ -31,26 +31,27 @@ ENV PATH $PATH:${ISPC_PATH}
 ENV EMBREE_VERSION 2.17.0
 ENV EMBREE_SRC /app/embree
 
-RUN mkdir -p ${EMBREE_SRC} && \
-    apt-get update && \
-    apt-get -y install ${BUILD_TOOLS} && \
-    apt-get -y install freeglut3-dev \
+RUN mkdir -p ${EMBREE_SRC} \
+ && apt-get update \
+ && apt-get -y install ${BUILD_TOOLS} \
+ && apt-get -y install freeglut3-dev \
     libtbb-dev \
     libxi-dev \
-    libxmu-dev && \
-    git clone https://github.com/embree/embree.git ${EMBREE_SRC} && \
-    cd ${EMBREE_SRC} && \
-    git checkout v${EMBREE_VERSION} && \
-    mkdir -p build && \
-    cd build && \
-    cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=${DIST_PATH} && \
-    ninja install && \
-    cd /app && \
-    rm -rf ${EMBREE_SRC} && \
-    apt-get -y remove ${BUILD_TOOLS} && \
-    apt-get -y remove freeglut3-dev libtbb-dev libxi-dev libxmu-dev && \
-    apt-get -y autoremove && \
-    apt-get clean
+    libxmu-dev \
+ && git clone https://github.com/embree/embree.git ${EMBREE_SRC} \
+ && cd ${EMBREE_SRC} \
+ && git checkout v${EMBREE_VERSION} \
+ && mkdir -p build \
+ && cd build \
+ && cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=${DIST_PATH} \
+ && ninja install \
+ && cd /app \
+ && rm -rf ${EMBREE_SRC} \
+ && apt-get -y remove ${BUILD_TOOLS} \
+ && apt-get -y remove freeglut3-dev libtbb-dev libxi-dev libxmu-dev \
+ && apt-get -y autoremove \
+ && apt-get clean
+
 
 
 # Install OSPray
@@ -58,28 +59,28 @@ RUN mkdir -p ${EMBREE_SRC} && \
 ENV OSPRAY_VERSION 1.4.0
 ENV OSPRAY_SRC /app/ospray
 
-RUN mkdir -p ${OSPRAY_SRC} && \
-    apt-get update && \
-    apt-get -y install ${BUILD_TOOLS} && \
-    apt-get -y install freeglut3-dev \
+RUN mkdir -p ${OSPRAY_SRC} \
+ && apt-get update \
+ && apt-get -y install ${BUILD_TOOLS} \
+ && apt-get -y install freeglut3-dev \
     libglu1-mesa-dev \
     libtbb-dev \
     libxi-dev \
     libxmu-dev \
-    xorg-dev && \
-    git clone https://github.com/ospray/ospray.git ${OSPRAY_SRC} && \
-    cd ${OSPRAY_SRC} && \
-    git checkout v${OSPRAY_VERSION} && \
-    mkdir -p build && \
-    cd build && \
-    cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=${DIST_PATH} && \
-    ninja install && \
-    cd /app && \
-    rm -rf ${OSPRAY_SRC} && \
-    apt-get -y remove ${BUILD_TOOLS} && \
-    apt-get -y remove freeglut3-dev libglu1-mesa-dev libtbb-dev libxi-dev libxmu-dev xorg-dev && \
-    apt-get -y autoremove && \
-    apt-get clean
+    xorg-dev \
+ && git clone https://github.com/ospray/ospray.git ${OSPRAY_SRC} \
+ && cd ${OSPRAY_SRC} \
+ && git checkout v${OSPRAY_VERSION} \
+ && mkdir -p build \
+ && cd build \
+ && cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=${DIST_PATH} \
+ && ninja install \
+ && cd /app \
+ && rm -rf ${OSPRAY_SRC} \
+ && apt-get -y remove ${BUILD_TOOLS} \
+ && apt-get -y remove freeglut3-dev libglu1-mesa-dev libtbb-dev libxi-dev libxmu-dev xorg-dev \
+ && apt-get -y autoremove \
+ && apt-get clean
 
 
 # Set working dir and copy Brayns assets
@@ -90,11 +91,11 @@ ADD . ${BRAYNS_SRC}
 
 # Install Brayns
 # https://github.com/BlueBrain/Brayns
-RUN cksum ${BRAYNS_SRC}/.gitsubprojects && \
-    cd ${BRAYNS_SRC} && \
-    apt-get update && \
-    apt-get -y install ${BUILD_TOOLS} && \
-    apt-get -y install libtbb-dev \
+RUN cksum ${BRAYNS_SRC}/.gitsubprojects \
+ && cd ${BRAYNS_SRC} \
+ && apt-get update \
+ && apt-get -y install ${BUILD_TOOLS} \
+ && apt-get -y install \
     freeglut3-dev \
     libassimp-dev \
     libboost-all-dev \
@@ -103,6 +104,7 @@ RUN cksum ${BRAYNS_SRC}/.gitsubprojects && \
     libhdf5-serial-dev \
     libjpeg-turbo8-dev \
     libmagick++-dev \
+    libtbb-dev \
     libturbojpeg \
     libxi-dev \
     libxmu-dev \
@@ -110,24 +112,23 @@ RUN cksum ${BRAYNS_SRC}/.gitsubprojects && \
     python-pyparsing \
     qtbase5-dev \
     qtdeclarative5-dev \
-    xorg-dev && \
-    git submodule update --init --recursive --remote && \
-    mkdir -p build && \
-    cd build && \
-    cmake .. -GNinja \
-    -DCMAKE_INSTALL_PREFIX=${DIST_PATH} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBRAYNS_NETWORKING_ENABLED=ON \
-    -DBRAYNS_DEFLECT_ENABLED=ON \
+    xorg-dev \
+ && git submodule update --init --recursive --remote \
+ && mkdir -p build \
+ && cd build \
+ && cmake .. -GNinja \
     -DBRAYNS_BRION_ENABLED=ON \
-    -DCLONE_SUBPROJECTS=ON && \
-    ninja install && \
-    cd /app && \
-    rm -rf ${BRAYNS_SRC}/build && \
-    apt-get -y remove ${BUILD_TOOLS} && \
-    apt-get -y purge *-dev python-pyparsing && \
-    apt-get clean
-
+    -DBRAYNS_DEFLECT_ENABLED=ON \
+    -DBRAYNS_NETWORKING_ENABLED=ON \
+    -DCLONE_SUBPROJECTS=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${DIST_PATH} \
+ && ninja install \
+ && cd /app \
+ && rm -rf ${BRAYNS_SRC}/build \
+ && apt-get -y remove ${BUILD_TOOLS} \
+ && apt-get -y purge *-dev python-pyparsing \
+ && apt-get clean
 
 # Add binaries from dist to the PATH
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:${DIST_PATH}/lib


### PR DESCRIPTION
On my way to make `braynsViewer` works within containers, here is a small contribution to shrink both Docker image size and build time.

Image size is now 437MB instead of >1GB

The patch leverages _multi-stage builds_, a feature released in Docker 17.05.
More information available in the [official user guide](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds)