### PR TITLE
Event-driven architecture for braynsService, resolve #286

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,4 +1,4 @@
-future-release=0.5.0
+future-release=0.6.0
 user=BlueBrain
 project=Brayns
 output=Changelog.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "CMake/common"]
 	path = CMake/common
 	url = https://github.com/Eyescale/CMake
+[submodule "uvw"]
+	path = uvw
+	url = https://github.com/skypjack/uvw.git

--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -2,7 +2,7 @@
 git_subproject(vmmlib https://github.com/Eyescale/vmmlib.git d7681fe)
 
 if(BRAYNS_NETWORKING_ENABLED)
-  git_subproject(Rockets https://github.com/BlueBrain/Rockets.git 8f0ef1c)
+  git_subproject(Rockets https://github.com/BlueBrain/Rockets.git b67cfad)
 endif()
 
 # Streaming to display walls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ common_find_package(OpenMP)
 common_find_package(libuv)
 
 if(libuv_FOUND)
+  # The libuv version of Ubuntu 16.04 is too old to have this definition that is
+  # required by uvw (in fact, it uses an old enough version as well to make
+  # things work, but couldn't go further).
   if(libuv_VERSION VERSION_LESS 1.9.0)
     add_definitions(-DUV_DISCONNECT=4)
   endif()
@@ -183,7 +186,7 @@ if(BRAYNS_OSPRAY_ENABLED)
       add_dependencies(braynsOSPRayEnginePlugin ospray_module_optix)
     endif()
   endif()
-  add_subdirectory(ospray_modules/opendeck) 
+  add_subdirectory(ospray_modules/opendeck)
 endif()
 
 set(DOXYGEN_EXTRA_INPUT "${PROJECT_SOURCE_DIR}/Changelog.md")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # This file is part of Brayns <https://github.com/BlueBrain/Brayns>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(Brayns VERSION 0.5.0)
+project(Brayns VERSION 0.6.0)
 set(Brayns_VERSION_ABI 1)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
@@ -37,11 +37,22 @@ common_find_package(Boost REQUIRED COMPONENTS
   filesystem system program_options unit_test_framework)
 common_find_package(vmmlib REQUIRED)
 common_find_package(OpenMP)
+common_find_package(libuv)
+
+if(libuv_FOUND)
+  if(libuv_VERSION VERSION_LESS 1.9.0)
+    add_definitions(-DUV_DISCONNECT=4)
+  endif()
+  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/uvw)
+    message(FATAL_ERROR "uvw missing, run: git submodule update --init")
+  endif()
+  include_directories(SYSTEM uvw/src)
+endif()
 
 # HTTP messaging
 common_find_package(LibJpegTurbo)
 common_find_package(Rockets)
-if(LibJpegTurbo_FOUND AND TARGET Rockets)
+if(TARGET Rockets)
   option(BRAYNS_NETWORKING_ENABLED "Activate networking interfaces" ON)
   if(BRAYNS_NETWORKING_ENABLED)
     list(APPEND COMMON_FIND_PACKAGE_DEFINES BRAYNS_USE_NETWORKING)
@@ -139,9 +150,13 @@ if(BRAYNS_VIEWER_ENABLED)
   add_subdirectory(apps/BraynsViewer)
 endif()
 
-option(BRAYNS_SERVICE_ENABLED "Brayns Service" ON)
-if(BRAYNS_SERVICE_ENABLED)
-  add_subdirectory(apps/BraynsService)
+if(libuv_FOUND)
+  option(BRAYNS_SERVICE_ENABLED "Brayns Service" ON)
+  if(BRAYNS_SERVICE_ENABLED)
+    add_subdirectory(apps/BraynsService)
+  endif()
+else()
+  unset(BRAYNS_SERVICE_ENABLED)
 endif()
 
 option(BRAYNS_BENCHMARK_ENABLED "Brayns Benchmark" ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     libmagick++-dev \
     libtbb-dev \
     libturbojpeg0-dev \
+    libuv1-dev \
     wget \
     ca-certificates \
  && apt-get clean \
@@ -109,7 +110,7 @@ ADD . ${BRAYNS_SRC}
 # https://github.com/BlueBrain/Brayns
 RUN cksum ${BRAYNS_SRC}/.gitsubprojects \
  && cd ${BRAYNS_SRC} \
- && git submodule update --init --recursive --remote \
+ && git submodule update --init --recursive \
  && mkdir -p build \
  && cd build \
  && PKG_CONFIG_PATH=${DIST_PATH}/lib/pkgconfig CMAKE_PREFIX_PATH=${DIST_PATH} cmake .. -GNinja \
@@ -141,6 +142,7 @@ RUN apt-get update \
     libmagick++-6.q16-7 \
     libmagickwand-6.q16-3 \
     libturbojpeg0 \
+    libuv1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/apps/BraynsService/CMakeLists.txt
+++ b/apps/BraynsService/CMakeLists.txt
@@ -7,7 +7,7 @@
 set(BRAYNSSERVICE_SOURCES main.cpp)
 
 set(BRAYNSSERVICE_LINK_LIBRARIES
-  PUBLIC brayns braynsCommon braynsIO braynsParameters
+  PUBLIC brayns braynsCommon braynsIO braynsParameters ${libuv_LIBRARIES}
 )
 
 common_application(braynsService)

--- a/apps/BraynsService/main.cpp
+++ b/apps/BraynsService/main.cpp
@@ -20,21 +20,149 @@
 
 #include <brayns/Brayns.h>
 #include <brayns/common/Timer.h>
+#include <brayns/common/engine/Engine.h>
 #include <brayns/common/log.h>
+#include <brayns/common/renderer/Renderer.h>
 #include <brayns/common/types.h>
+
+#include <uvw.hpp>
+
+#include <thread>
 
 int main(int argc, const char** argv)
 {
     try
     {
         BRAYNS_INFO << "Initializing Service..." << std::endl;
-        brayns::Brayns brayns(argc, argv);
 
         brayns::Timer timer;
         timer.start();
-        bool keepRunning = true;
-        while (keepRunning)
-            keepRunning = brayns.render();
+
+        brayns::Brayns brayns(argc, argv);
+
+        auto mainLoop = uvw::Loop::getDefault();
+        auto renderingDone = mainLoop->resource<uvw::AsyncHandle>();
+        auto eventRendering = mainLoop->resource<uvw::IdleHandle>();
+        auto accumRendering = mainLoop->resource<uvw::IdleHandle>();
+        auto progressUpdate = mainLoop->resource<uvw::TimerHandle>();
+        auto checkIdleRendering = mainLoop->resource<uvw::CheckHandle>();
+        checkIdleRendering->start();
+
+        auto renderLoop = uvw::Loop::create();
+        auto triggerRendering = renderLoop->resource<uvw::AsyncHandle>();
+        auto stopRenderThread = renderLoop->resource<uvw::AsyncHandle>();
+
+        // main thread
+        const float idleRenderingDelay = 0.1f;
+        bool isLoading = false;
+        brayns::Timer timeSinceLastEvent;
+        {
+            // triggered after rendering, send events to rockets
+            renderingDone->on<uvw::AsyncEvent>(
+                [&](const auto&, auto&) { brayns.postRender(); });
+
+            // events from rockets
+            brayns.getEngine().triggerRender = [&] { eventRendering->start(); };
+
+            // render or data load trigger from events
+            eventRendering->on<uvw::IdleEvent>([&](const auto&, auto&) {
+                eventRendering->stop();
+                accumRendering->stop();
+                timeSinceLastEvent.start();
+
+                // stop event loop(s) and exit application
+                if (!brayns.getEngine().getKeepRunning())
+                {
+                    stopRenderThread->send();
+                    mainLoop->stop();
+                    return;
+                }
+
+                // data loading
+                if (brayns.getEngine().rebuildScene())
+                {
+                    if (isLoading)
+                        return;
+
+                    isLoading = true;
+
+                    checkIdleRendering->stop();
+
+                    // broadcast progress updates every 100ms
+                    progressUpdate->start(std::chrono::milliseconds(0),
+                                          std::chrono::milliseconds(100));
+
+                    // async load execution
+                    auto work = mainLoop->resource<uvw::WorkReq>(
+                        [&] { brayns.buildScene(); });
+
+                    // async load finished, restore everything to continue
+                    // rendering
+                    work->template on<uvw::WorkEvent>([&](const auto&, auto&) {
+                        brayns.getEngine().markRebuildScene(false);
+                        progressUpdate->stop();
+                        progressUpdate->close();
+                        isLoading = false;
+
+                        checkIdleRendering->start();
+                        eventRendering->start();
+                    });
+
+                    work->queue();
+                    return;
+                }
+
+                // rendering
+                if (brayns.preRender())
+                    triggerRendering->send();
+            });
+
+            // send progress updates while we are loading
+            progressUpdate->on<uvw::TimerEvent>(
+                [&](const auto&, auto&) { brayns.postRender(); });
+
+            // send final progress update, once loading is finished
+            progressUpdate->on<uvw::CloseEvent>(
+                [&](const auto&, auto&) { brayns.postRender(); });
+
+            // start accum rendering when we have no more other events
+            checkIdleRendering->on<uvw::CheckEvent>(
+                [&](const auto&, auto&) { accumRendering->start(); });
+
+            // render trigger from going into idle
+            accumRendering->on<uvw::IdleEvent>([&](const auto&, auto&) {
+                if (timeSinceLastEvent.elapsed() < idleRenderingDelay)
+                    return;
+
+                if (brayns.preRender() &&
+                    brayns.getEngine().continueRendering())
+                    triggerRendering->send();
+
+                accumRendering->stop();
+            });
+        }
+
+        // render thread
+        {
+            // rendering
+            triggerRendering->on<uvw::AsyncEvent>([&](const auto&, auto&) {
+                brayns.renderOnly();
+                renderingDone->send();
+            });
+
+            // stop render loop
+            stopRenderThread->once<uvw::AsyncEvent>(
+                [&](const auto&, auto&) { renderLoop->stop(); });
+        }
+
+        brayns.createPlugins();
+
+        // Start render & main loop
+        std::thread renderThread([&] { renderLoop->run(); });
+        mainLoop->run();
+
+        // Finished
+        renderThread.join();
         timer.stop();
         BRAYNS_INFO << "Service was running for " << timer.seconds()
                     << " seconds" << std::endl;

--- a/apps/BraynsViewer/BraynsViewer.cpp
+++ b/apps/BraynsViewer/BraynsViewer.cpp
@@ -22,13 +22,17 @@
 #include "BraynsViewer.h"
 
 #include <brayns/Brayns.h>
+#include <brayns/common/engine/Engine.h>
 #include <brayns/parameters/ParametersManager.h>
+
+#include <thread>
 
 namespace brayns
 {
 BraynsViewer::BraynsViewer(Brayns& brayns)
     : BaseWindow(brayns)
 {
+    brayns.createPlugins();
 }
 
 void BraynsViewer::display()
@@ -49,5 +53,11 @@ void BraynsViewer::display()
     setTitle(ss.str());
 
     BaseWindow::display();
+
+    if (_brayns.getEngine().rebuildScene())
+    {
+        _brayns.getEngine().markRebuildScene(false);
+        std::thread([& brayns = _brayns]() { brayns.buildScene(); }).detach();
+    }
 }
 }

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -38,7 +38,6 @@
 
 #include <brayns/parameters/ParametersManager.h>
 
-#include <brayns/io/ImageManager.h>
 #include <brayns/io/MeshLoader.h>
 #include <brayns/io/MolecularSystemReader.h>
 #include <brayns/io/ProteinLoader.h>
@@ -47,11 +46,15 @@
 #include <brayns/io/simulation/SpikeSimulationHandler.h>
 
 #include <plugins/engines/EngineFactory.h>
-#if (BRAYNS_USE_DEFLECT || BRAYNS_USE_NETWORKING)
 #include <plugins/extensions/ExtensionPluginFactory.h>
+#ifdef BRAYNS_USE_NETWORKING
+#include <plugins/extensions/plugins/RocketsPlugin.h>
+#endif
+#ifdef BRAYNS_USE_DEFLECT
+#include <plugins/extensions/plugins/DeflectPlugin.h>
 #endif
 
-#if (BRAYNS_USE_BRION)
+#ifdef BRAYNS_USE_BRION
 #include <brayns/io/ConnectivityLoader.h>
 #include <brayns/io/MorphologyLoader.h>
 #include <brayns/io/NESTLoader.h>
@@ -96,14 +99,113 @@ struct Brayns::Impl
 
         createEngine();
 
-#if (BRAYNS_USE_DEFLECT || BRAYNS_USE_NETWORKING)
-        // after createEngine() to execute in parallel to scene loading
-        _extensionPluginFactory.reset(
-            new ExtensionPluginFactory(_parametersManager));
-#endif
-
         if (!isAsyncMode())
             _finishLoadScene();
+    }
+
+    void createPlugins()
+    {
+#if (BRAYNS_USE_NETWORKING)
+        _extensionPluginFactory.add(
+            std::make_shared<RocketsPlugin>(_engine, _parametersManager));
+#endif
+#ifdef BRAYNS_USE_DEFLECT
+        _extensionPluginFactory.add(
+            std::make_shared<DeflectPlugin>(_engine, _parametersManager));
+#endif
+    }
+
+    bool preRender()
+    {
+        std::lock_guard<std::mutex> lock{_renderMutex};
+
+        if (!isLoadingFinished())
+        {
+#ifdef BRAYNS_USE_LUNCHBOX
+            if (isAsyncMode())
+            {
+                postRender();
+
+                return false;
+            }
+#endif
+            _finishLoadScene();
+        }
+        else if (_dataLoadingFuture.valid())
+            _finishLoadScene();
+
+        _extensionPluginFactory.preRender(_keyboardHandler,
+                                          *_cameraManipulator);
+
+        _updateAnimation();
+
+        _engine->setActiveRenderer(
+            _parametersManager.getRenderingParameters().getRenderer());
+
+        const Vector2ui windowSize =
+            _parametersManager.getApplicationParameters().getWindowSize();
+
+        _engine->reshape(windowSize);
+        _engine->preRender();
+
+        _engine->commit();
+
+        Camera& camera = _engine->getCamera();
+        camera.commit();
+
+        Scene& scene = _engine->getScene();
+
+        if (scene.getTransferFunction().isModified())
+            scene.commitTransferFunctionData();
+
+        if (_parametersManager.getRenderingParameters().getHeadLight())
+        {
+            LightPtr sunLight = scene.getLight(0);
+            auto sun = std::dynamic_pointer_cast<DirectionalLight>(sunLight);
+            if (sun &&
+                (camera.isModified() ||
+                 _parametersManager.getRenderingParameters().isModified()))
+            {
+                sun->setDirection(camera.getTarget() - camera.getPosition());
+                scene.commitLights();
+            }
+        }
+
+        if (_parametersManager.isAnyModified() || camera.isModified() ||
+            scene.isModified())
+        {
+            _engine->getFrameBuffer().clear();
+        }
+
+        _engine->getScene().getTransferFunction().resetModified();
+        _parametersManager.resetModified();
+        _engine->getCamera().resetModified();
+        _engine->getScene().resetModified();
+
+        return true;
+    }
+
+    void postRender()
+    {
+        _engine->postRender();
+
+        _fpsUpdateElapsed += _renderTimer.milliseconds();
+        if (_fpsUpdateElapsed > 750)
+        {
+            _engine->getStatistics().setFPS(_renderTimer.perSecondSmoothed());
+            _fpsUpdateElapsed = 0;
+        }
+
+        // WAR to keep clients updated about current animation frame
+        auto& ap = _parametersManager.getAnimationParameters();
+        if (ap.getDelta() != 0)
+            ap.markModified();
+
+        _extensionPluginFactory.postRender();
+
+        _engine->getProgress().resetModified();
+        _engine->getFrameBuffer().resetModified();
+        _engine->getStatistics().resetModified();
     }
 
     void createEngine()
@@ -119,7 +221,6 @@ struct Brayns::Impl
                 _parametersManager.getRenderingParameters().getEngineAsString(
                     engineName));
 
-        _engine->buildScene = std::bind(&Impl::buildScene, this);
         _setupCameraManipulator(CameraMode::inspect);
 
         // Default sun light
@@ -134,65 +235,70 @@ struct Brayns::Impl
 
     void buildScene()
     {
-        _engine->setReady(false);
+        if (!isLoadingFinished())
+            throw std::runtime_error("Build scene already in progress");
 
         _engine->setLastOperation("");
         _engine->setLastProgress(0);
 
+        std::promise<void> promise;
+        _dataLoadingFuture = promise.get_future();
+
 #ifdef BRAYNS_USE_LUNCHBOX
         if (isAsyncMode())
-        {
-            _dataLoadingFuture =
-                _loadingThread.post(std::bind(&Brayns::Impl::_loadScene, this));
-        }
+            _loadingThread.post(std::bind(&Brayns::Impl::_loadScene, this))
+                .get();
         else
 #endif
-            _dataLoadingFuture =
-                std::async(std::launch::deferred,
-                           std::bind(&Brayns::Impl::_loadScene, this));
+            std::async(std::launch::deferred,
+                       std::bind(&Brayns::Impl::_loadScene, this))
+                .get();
+
+        promise.set_value();
     }
 
-    void render(const RenderInput& renderInput, RenderOutput& renderOutput)
+    bool preRender(const RenderInput& renderInput)
     {
         _engine->getCamera().set(renderInput.position, renderInput.target,
                                  renderInput.up);
+        _parametersManager.getApplicationParameters().setWindowSize(
+            renderInput.windowSize);
 
-        if (_render(renderInput.windowSize))
-        {
-            FrameBuffer& frameBuffer = _engine->getFrameBuffer();
-            const Vector2i& frameSize = frameBuffer.getSize();
-            uint8_t* colorBuffer = frameBuffer.getColorBuffer();
-            if (colorBuffer)
-            {
-                const size_t size =
-                    frameSize.x() * frameSize.y() * frameBuffer.getColorDepth();
-                renderOutput.colorBuffer.assign(colorBuffer,
-                                                colorBuffer + size);
-                renderOutput.colorBufferFormat =
-                    frameBuffer.getFrameBufferFormat();
-            }
-
-            float* depthBuffer = frameBuffer.getDepthBuffer();
-            if (depthBuffer)
-            {
-                const size_t size = frameSize.x() * frameSize.y();
-                renderOutput.depthBuffer.assign(depthBuffer,
-                                                depthBuffer + size);
-            }
-        }
-
-        _engine->postRender();
+        return preRender();
     }
 
-    bool render()
+    void postRender(RenderOutput& renderOutput)
     {
-        const Vector2ui windowSize =
-            _parametersManager.getApplicationParameters().getWindowSize();
-        _render(windowSize);
+        FrameBuffer& frameBuffer = _engine->getFrameBuffer();
+        frameBuffer.map();
+        const Vector2i& frameSize = frameBuffer.getSize();
+        uint8_t* colorBuffer = frameBuffer.getColorBuffer();
+        if (colorBuffer)
+        {
+            const size_t size =
+                frameSize.x() * frameSize.y() * frameBuffer.getColorDepth();
+            renderOutput.colorBuffer.assign(colorBuffer, colorBuffer + size);
+            renderOutput.colorBufferFormat = frameBuffer.getFrameBufferFormat();
+        }
 
-        _engine->postRender();
+        float* depthBuffer = frameBuffer.getDepthBuffer();
+        if (depthBuffer)
+        {
+            const size_t size = frameSize.x() * frameSize.y();
+            renderOutput.depthBuffer.assign(depthBuffer, depthBuffer + size);
+        }
+        frameBuffer.unmap();
 
-        return _engine->getKeepRunning();
+        postRender();
+    }
+
+    void render()
+    {
+        std::lock_guard<std::mutex> lock{_renderMutex};
+
+        _renderTimer.start();
+        _engine->render();
+        _renderTimer.stop();
     }
 
     Engine& getEngine() { return *_engine; }
@@ -212,33 +318,16 @@ struct Brayns::Impl
     }
 
 private:
-    void _writeFrameToFile()
-    {
-        const auto& frameExportFolder =
-            _parametersManager.getApplicationParameters()
-                .getFrameExportFolder();
-        if (frameExportFolder.empty())
-            return;
-        char str[7];
-        const auto frame =
-            _parametersManager.getAnimationParameters().getFrame();
-        snprintf(str, 7, "%06d", int(frame));
-        const auto filename = frameExportFolder + "/" + str + ".png";
-        FrameBuffer& frameBuffer = _engine->getFrameBuffer();
-        ImageManager::exportFrameBufferToFile(frameBuffer, filename);
-    }
-
     void _loadScene()
     {
         // fix race condition: we have to wait until rendering is finished
-        while (_rendering)
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::lock_guard<std::mutex> lock{_renderMutex};
 
         Progress loadingProgress(
             "Loading scene ...",
             LOADING_PROGRESS_DATA + 3 * LOADING_PROGRESS_STEP,
             [this](const std::string& msg, const float progress) {
-                std::lock_guard<std::mutex> lock(_engine->getProgress().mutex);
+                std::lock_guard<std::mutex> lock_(_engine->getProgress().mutex);
                 _engine->setLastOperation(msg);
                 _engine->setLastProgress(progress);
             });
@@ -275,7 +364,6 @@ private:
         loadingProgress += LOADING_PROGRESS_STEP;
 
         loadingProgress.setMessage("Done");
-        _engine->setReady(true);
         BRAYNS_INFO << "Now rendering ..." << std::endl;
     }
 
@@ -292,6 +380,9 @@ private:
 
         _engine->getStatistics().setSceneSizeInBytes(
             _engine->getScene().getSizeInBytes());
+
+        // finish reporting of progress
+        postRender();
     }
 
     void _updateAnimation()
@@ -301,108 +392,11 @@ private:
 
         auto simHandler = _engine->getScene().getSimulationHandler();
         auto& animParams = _parametersManager.getAnimationParameters();
-        if ((animParams.getModified() || animParams.getDelta() != 0) &&
+        if ((animParams.isModified() || animParams.getDelta() != 0) &&
             simHandler && simHandler->isReady())
         {
             animParams.setFrame(animParams.getFrame() + animParams.getDelta());
         }
-    }
-
-    bool _render(const Vector2ui& windowSize)
-    {
-        _updateAnimation();
-
-        _extensionPluginFactory->execute(_engine, _keyboardHandler,
-                                         *_cameraManipulator);
-
-        _engine->getStatistics().resetModified();
-
-        _engine->reshape(windowSize);
-        _engine->preRender();
-
-        if (!isLoadingFinished())
-        {
-#ifdef BRAYNS_USE_LUNCHBOX
-            if (isAsyncMode())
-            {
-                _parametersManager.resetModified();
-                _engine->getProgress().resetModified();
-
-                // limit any updates (Deflect, Rockets) to a reasonable number
-                // while we are loading (and not rendering).
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                return false;
-            }
-#endif
-            _finishLoadScene();
-        }
-        else if (_dataLoadingFuture.valid())
-            _finishLoadScene();
-
-        _rendering = true;
-        _renderTimer.start();
-
-        _engine->commit();
-
-        Camera& camera = _engine->getCamera();
-        camera.commit();
-
-        Scene& scene = _engine->getScene();
-
-        if (scene.getTransferFunction().getModified())
-        {
-            scene.commitTransferFunctionData();
-            scene.getTransferFunction().resetModified();
-        }
-
-        if (_parametersManager.getRenderingParameters().getHeadLight())
-        {
-            LightPtr sunLight = scene.getLight(0);
-            DirectionalLight* sun =
-                dynamic_cast<DirectionalLight*>(sunLight.get());
-            if (sun &&
-                (camera.getModified() ||
-                 _parametersManager.getRenderingParameters().getModified()))
-            {
-                sun->setDirection(camera.getTarget() - camera.getPosition());
-                scene.commitLights();
-            }
-        }
-
-        _engine->setActiveRenderer(
-            _parametersManager.getRenderingParameters().getRenderer());
-
-        if (_parametersManager.isAnyModified() || camera.getModified() ||
-            scene.getModified())
-        {
-            _engine->getRenderer().hasNewImage(true);
-            _engine->getFrameBuffer().clear();
-        }
-        else
-            // we assume no new image here, but accumulation inside the renderer
-            // might decide otherwise
-            _engine->getRenderer().hasNewImage(false);
-
-        _engine->render();
-
-        _writeFrameToFile();
-
-        _parametersManager.resetModified();
-        camera.resetModified();
-        scene.resetModified();
-        _engine->getProgress().resetModified();
-
-        _rendering = false;
-        _renderTimer.stop();
-
-        _fpsUpdateElapsed += _renderTimer.milliseconds();
-        if (_fpsUpdateElapsed > 750)
-        {
-            _engine->getStatistics().setFPS(_renderTimer.perSecondSmoothed());
-            _fpsUpdateElapsed = 0;
-        }
-
-        return true;
     }
 
     void _loadData(Progress& loadingProgress)
@@ -1218,8 +1212,8 @@ private:
 
     std::future<void> _dataLoadingFuture;
 
-    // protect rendering vs. data loading/unloading
-    std::atomic_bool _rendering{false};
+    // protect render() vs preRender() when doing all the commit()
+    std::mutex _renderMutex;
 
     Timer _renderTimer;
     int64_t _fpsUpdateElapsed{0};
@@ -1232,9 +1226,7 @@ private:
     lunchbox::ThreadPool _loadingThread{1};
 #endif
 
-#if (BRAYNS_USE_DEFLECT || BRAYNS_USE_NETWORKING)
-    ExtensionPluginFactoryPtr _extensionPluginFactory;
-#endif
+    ExtensionPluginFactory _extensionPluginFactory;
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -1250,17 +1242,53 @@ Brayns::~Brayns()
 
 void Brayns::render(const RenderInput& renderInput, RenderOutput& renderOutput)
 {
-    _impl->render(renderInput, renderOutput);
+    if (_impl->preRender(renderInput))
+    {
+        _impl->render();
+        _impl->postRender(renderOutput);
+    }
 }
 
 bool Brayns::render()
 {
+    if (_impl->preRender())
+    {
+        _impl->render();
+        _impl->postRender();
+    }
+    return _impl->getEngine().getKeepRunning();
+}
+
+void Brayns::createPlugins()
+{
+    _impl->createPlugins();
+}
+
+bool Brayns::preRender()
+{
+    return _impl->preRender();
+}
+
+void Brayns::renderOnly()
+{
     return _impl->render();
 }
+
+void Brayns::postRender()
+{
+    _impl->postRender();
+}
+
+void Brayns::buildScene()
+{
+    _impl->buildScene();
+}
+
 Engine& Brayns::getEngine()
 {
     return _impl->getEngine();
 }
+
 ParametersManager& Brayns::getParametersManager()
 {
     return _impl->getParametersManager();

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -250,9 +250,7 @@ struct Brayns::Impl
                 .get();
         else
 #endif
-            std::async(std::launch::deferred,
-                       std::bind(&Brayns::Impl::_loadScene, this))
-                .get();
+            _loadScene();
 
         promise.set_value();
     }

--- a/brayns/Brayns.h
+++ b/brayns/Brayns.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *                     Jafet Villafranca <jafet.villafrancadiaz@epfl.ch>
@@ -43,7 +43,8 @@ namespace brayns
     in the rendering parameters and is invoked by the render method for
     generating the frames.
 
-    Underlying rendering engines support CPU, GPU and heterogeneous architectures
+    Underlying rendering engines support CPU, GPU and heterogeneous
+   architectures
 
     This object exposes the basic API for Brayns
 */
@@ -54,27 +55,82 @@ public:
     BRAYNS_API ~Brayns();
 
     /**
-       Renders color and depth buffers of the current scene, according to
-       specified parameters
-       @param renderInput Rendering parameters such as the position of the
-              camera and according model and projection matrices
-       @param renderOutput Color and depth buffers
-    */
+     * Creates all registered plugins. Shall be invoked before starting any
+     * rendering.
+     *
+     * In a setup using event loops, one wants to postpone this call until the
+     * event loop is setup'd correctly to use it from within a plugin.
+     */
+    BRAYNS_API void createPlugins();
+
+    /** @name Simple execution API  */
+    //@{
+    /**
+     * Renders color and depth buffers of the current scene, according to
+     * specified parameters.
+     *
+     * Combines preRender(), renderOnly() and postRender() together in a
+     * synchronized fashion.
+     *
+     * @param renderInput Rendering parameters such as the position of the
+     *        camera and according model and projection matrices
+     * @param renderOutput Color and depth buffers
+     */
     BRAYNS_API void render(const RenderInput& renderInput,
                            RenderOutput& renderOutput);
 
     /**
-       Renders color and depth buffers of the current scene, according to
-       default parameters. This is typically used by an application that does
-       not provide any on-screen visualization. In such cases, input and output
-       parameters are provided by network events. For instance, a camera event
-       defines the origin, target and up vector of the camera, and an ImageJPEG
-       event triggers the rendering and gathers the results in a form of a
-       base64 encoded JPEG image.
-       @return true if rendering should continue or false if user inputs
-       requested to stop.
+     * Renders color and depth buffers of the current scene, according to
+     * default parameters. This is typically used by an application that does
+     * not provide any on-screen visualization. In such cases, input and output
+     * parameters are provided by network events. For instance, a camera event
+     * defines the origin, target and up vector of the camera, and an ImageJPEG
+     * event triggers the rendering and gathers the results in a form of a
+     * base64 encoded JPEG image.
+     *
+     * Combines preRender(), renderOnly() and postRender() together in a
+     * synchronized fashion.
+     *
+     * @return true if rendering should continue or false if user inputs
+     *         requested to stop.
     */
     BRAYNS_API bool render();
+    //@}
+
+    /** @name Low-level execution API */
+    //@{
+    /**
+     * Handle events, update animation, call preRender() on plugins and commit
+     * changes on the engine, scene, camera, renderer, etc. to prepare rendering
+     * of a new frame.
+     *
+     * @return true if renderOnly() is allowed/needed after all states have been
+     *         evaluated (accum rendering, data loading, etc.)
+     * @note threadsafe with renderOnly()
+     */
+    BRAYNS_API bool preRender();
+
+    /**
+     * Render a frame into the current framebuffer.
+     * @note threadsafe with preRender()
+     */
+    BRAYNS_API void renderOnly();
+
+    /**
+     * Call postRender() on engine and plugins to signal finish of renderOnly().
+     * Shall only be called after renderOnly() has finished.
+     */
+    BRAYNS_API void postRender();
+
+    /**
+     * Unloads current scene and loads new scene according to parameters. Can be
+     * called from a different thread to notify on updates during loading with
+     * postRender().
+     *
+     * @throw std::runtime_error if a previous buildScene() has not finished yet
+     */
+    BRAYNS_API void buildScene();
+    //@}
 
     /**
        @return the current engine

--- a/brayns/common/BaseObject.h
+++ b/brayns/common/BaseObject.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  *
  * Responsible Author: Daniel.Nachbaur@epfl.ch
  *
@@ -32,9 +32,9 @@ public:
 
     /**
      * @return true if any parameter has been modified since the last
-     * resetModified().
+     *         resetModified().
      */
-    bool getModified() const { return _modified; }
+    bool isModified() const { return _modified; }
     /**
      * Reset the modified state, typically done after changes have been applied.
      */

--- a/brayns/common/camera/Camera.cpp
+++ b/brayns/common/camera/Camera.cpp
@@ -35,6 +35,33 @@ Camera::~Camera()
 {
 }
 
+Camera& Camera::operator=(const Camera& rhs)
+{
+    if (this == &rhs)
+        return *this;
+
+    setPosition(rhs.getPosition());
+    setTarget(rhs.getTarget());
+    setUp(rhs.getUp());
+
+    _initialPosition = rhs._initialPosition;
+    _initialTarget = rhs._initialTarget;
+    _initialUp = rhs._initialUp;
+
+    setAspectRatio(getAspectRatio());
+    setAperture(getAperture());
+    setFocalLength(getFocalLength());
+    setFieldOfView(getFieldOfView());
+    setStereoMode(getStereoMode());
+    setEyeSeparation(getEyeSeparation());
+
+    setClipPlanes(getClipPlanes());
+
+    _matrix = rhs._matrix;
+
+    return *this;
+}
+
 void Camera::set(const Vector3f& position, const Vector3f& target,
                  const Vector3f& upVector)
 {

--- a/brayns/common/camera/Camera.h
+++ b/brayns/common/camera/Camera.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *                     Jafet Villafranca <jafet.villafrancadiaz@epfl.ch>
@@ -46,6 +46,8 @@ public:
     BRAYNS_API Camera(CameraType cameraType);
 
     BRAYNS_API virtual ~Camera();
+
+    BRAYNS_API Camera& operator=(const Camera& rhs);
 
     /**
        Sets position, target and up vector
@@ -215,7 +217,7 @@ public:
     */
     const ClipPlanes& getClipPlanes() const { return _clipPlanes; }
 private:
-    CameraType _type{CameraType::default_};
+    const CameraType _type{CameraType::default_};
     Vector3f _position;
     Vector3f _target;
     Vector3f _up;

--- a/brayns/common/engine/Engine.cpp
+++ b/brayns/common/engine/Engine.cpp
@@ -110,7 +110,7 @@ void Engine::commit()
 void Engine::render()
 {
     auto fb = _snapshotFrameBuffer ? _snapshotFrameBuffer : _frameBuffer;
-    _lastVariance = _renderers[_activeRenderer]->render(fb);
+    _renderers[_activeRenderer]->render(fb);
 }
 
 void Engine::postRender()
@@ -171,7 +171,8 @@ bool Engine::continueRendering() const
         return _snapshotFrameBuffer->numAccumFrames() < size_t(_snapshotSpp);
     }
 
-    return _lastVariance > 1 && _frameBuffer->getAccumulation() &&
+    return _renderers.at(_activeRenderer)->getVariance() > 1 &&
+           _frameBuffer->getAccumulation() &&
            (_frameBuffer->numAccumFrames() <
             _parametersManager.getRenderingParameters().getMaxAccumFrames());
 }

--- a/brayns/common/engine/Engine.h
+++ b/brayns/common/engine/Engine.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -54,23 +54,21 @@ public:
     explicit Engine(ParametersManager& parametersManager);
     virtual ~Engine();
 
-    /**
-       @return the name of the engine
-    */
+    /** @return the name of the engine */
     virtual EngineType name() const = 0;
 
     /**
-       Commits changes to the engine. This include scene and camera
-       modifications
-    */
-    virtual void commit() = 0;
+     * Commits changes to the engine. This include scene, camera and renderer
+     * modifications
+     */
+    virtual void commit();
 
     /** Renders the current scene and populates the frame buffer accordingly */
-    virtual void render();
+    void render();
     /** Executes engine specific pre-render operations */
     virtual void preRender() {}
     /** Executes engine specific post-render operations */
-    virtual void postRender() {}
+    virtual void postRender();
     /** Gets the scene */
     Scene& getScene() { return *_scene; }
     /** Gets the frame buffer */
@@ -108,22 +106,20 @@ public:
     void initializeMaterials(
         MaterialsColorMap colorMap = MaterialsColorMap::none);
 
-    /**
-     * Unloads the current scene and loads and builds a new scene according to
-     * datasource parameters. The execution will be asynchronous if
-     * getSynchronousMode() is false.
-     */
-    std::function<void()> buildScene;
+    /** Mark the scene for building with Brayns::buildScene(). */
+    void markRebuildScene(const bool rebuild = true)
+    {
+        _rebuildScene = rebuild;
+    }
 
+    /** @return true if Brayns::buildScene() shall be called. */
+    bool rebuildScene() const { return _rebuildScene; }
     /**
-     * @brief resets frame number
+     * Callback when a new frame shall be triggered. Currently called by event
+     * plugins Deflect and Rockets.
      */
-    void resetFrameNumber();
+    std::function<void()> triggerRender;
 
-    /**
-     * @returns the current frame number
-     */
-    size_t getFrameNumber() const { return _frameNumber; }
     /**
      * Adapts the size of the frame buffer according to camera
      * requirements. Typically, in case of 3D stereo vision, the frame buffer
@@ -182,28 +178,55 @@ public:
      * @return true if the user wants to continue rendering, false otherwise.
      */
     bool getKeepRunning() const { return _keepRunning; }
-    /**
-     * @return true if the engine is ready to render and receive updates, false
-     *         if data loading is in progress.
-     */
-    bool isReady() const { return _isReady; }
-    /** @internal */
-    void setReady(const bool isReady_) { _isReady = isReady_; }
     Statistics& getStatistics() { return _statistics; }
+    using SnapshotReadyCallback = std::function<void(FrameBufferPtr)>;
+
     /**
-     * Render a snapshot with the given parameters. Result is available in
-     * framebuffer.
+     * Setup render of a snapshot with the given parameters. Calls to render()
+     * start updating the framebuffer that will be provided in the ready
+     * callback, once the snapshot is ready according to given parameters.
+     * Currently determined by the number of accumulation samples.
      *
-     * @note not threadsafe and not safe vs render()
+     * Once the snaphot is done or cancelled, the framebuffer is reset and
+     * render() continues normally.
+     *
+     * If the snapshot creation has been cancelled with cancelSnapshot(), the
+     * ready callback will not be called.
+     *
      * @param params the snapshot parameter to take
-     * @throws std::runtime_error if engine is not ready or snapshot creation
-     *         failed
+     * @param cb callback when the snapshot is ready and can be obtained from
+     *           the given framebuffer
+     * @throws std::runtime_error if a previous snapshot creation has not been
+     *                            finished yet
      */
-    void snapshot(const SnapshotParams& params);
+    void snapshot(const SnapshotParams& params, SnapshotReadyCallback cb);
+
+    /**
+     * Cancel a current pending snapshot. Will reset the framebuffer, so that
+     * render() continues normally.
+     */
+    void cancelSnapshot() { _snapshotCancelled = true; }
+    /**
+     * @return true if render() calls shall be continued, based on current
+     *         accumulation and snapshot settings.
+     * @sa RenderingParameters::setMaxAccumFrames
+     */
+    bool continueRendering() const;
+
+    /** Factory method to create an engine-specific framebuffer. */
+    virtual FrameBufferPtr createFrameBuffer(
+        const Vector2ui& frameSize, FrameBufferFormat frameBufferFormat,
+        bool accumulation) = 0;
+
+    /** Factory method to create an engine-specific camera. */
+    virtual CameraPtr createCamera(CameraType type) = 0;
 
 protected:
     void _render(const RenderInput& renderInput, RenderOutput& renderOutput);
     void _render();
+
+    void _processSnapshot();
+    void _writeFrameToFile();
 
     ParametersManager& _parametersManager;
     ScenePtr _scene;
@@ -214,10 +237,17 @@ protected:
     FrameBufferPtr _frameBuffer;
     Statistics _statistics;
 
-    size_t _frameNumber;
     Progress _progress;
     bool _keepRunning{true};
-    bool _isReady{false};
+    float _lastVariance{std::numeric_limits<float>::infinity()};
+    bool _rebuildScene{false};
+
+    int _snapshotSpp{0};
+    int _restoreSpp{0};
+    SnapshotReadyCallback _cb;
+    FrameBufferPtr _snapshotFrameBuffer;
+    CameraPtr _snapshotCamera;
+    bool _snapshotCancelled{false};
 };
 }
 

--- a/brayns/common/engine/Engine.h
+++ b/brayns/common/engine/Engine.h
@@ -239,7 +239,6 @@ protected:
 
     Progress _progress;
     bool _keepRunning{true};
-    float _lastVariance{std::numeric_limits<float>::infinity()};
     bool _rebuildScene{false};
 
     int _snapshotSpp{0};

--- a/brayns/common/renderer/FrameBuffer.h
+++ b/brayns/common/renderer/FrameBuffer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -22,18 +22,19 @@
 #define FRAMEBUFFER_H
 
 #include <brayns/api.h>
+#include <brayns/common/BaseObject.h>
 #include <brayns/common/types.h>
 
 namespace brayns
 {
-class FrameBuffer
+class FrameBuffer : public BaseObject
 {
 public:
     BRAYNS_API FrameBuffer(const Vector2ui& frameSize,
                            FrameBufferFormat frameBufferFormat,
                            bool accumulation = true);
     virtual ~FrameBuffer() {}
-    virtual void clear() = 0;
+    virtual void clear() { _accumFrames = 0; }
     virtual void map() = 0;
     virtual void unmap() = 0;
 
@@ -54,10 +55,13 @@ public:
         return _frameBufferFormat;
     }
 
+    void incrementAccumFrames() { ++_accumFrames; }
+    size_t numAccumFrames() const { return _accumFrames; }
 protected:
     Vector2ui _frameSize;
     FrameBufferFormat _frameBufferFormat;
     bool _accumulation;
+    size_t _accumFrames{0};
 };
 }
 #endif // FRAMEBUFFER_H

--- a/brayns/common/renderer/Renderer.h
+++ b/brayns/common/renderer/Renderer.h
@@ -31,8 +31,10 @@ class Renderer
 public:
     BRAYNS_API Renderer(ParametersManager& parametersManager);
     virtual ~Renderer() {}
-    virtual float render(FrameBufferPtr frameBuffer) = 0;
+    virtual void render(FrameBufferPtr frameBuffer) = 0;
 
+    /** @return the variance from the previous render(). */
+    virtual float getVariance() const { return 0.f; }
     virtual void commit() = 0;
     void setScene(ScenePtr scene) { _scene = scene; };
     virtual void setCamera(CameraPtr camera) = 0;

--- a/brayns/common/types.h
+++ b/brayns/common/types.h
@@ -164,7 +164,6 @@ typedef std::shared_ptr<ExtensionPlugin> ExtensionPluginPtr;
 typedef std::vector<ExtensionPluginPtr> ExtensionPlugins;
 
 class ExtensionPluginFactory;
-typedef std::unique_ptr<ExtensionPluginFactory> ExtensionPluginFactoryPtr;
 
 class RocketsPlugin;
 

--- a/brayns/io/ImageManager.cpp
+++ b/brayns/io/ImageManager.cpp
@@ -54,12 +54,14 @@ bool ImageManager::exportFrameBufferToFile(
                          << std::endl;
             return false;
         }
+        frameBuffer.map();
         uint8_t* colorBuffer = frameBuffer.getColorBuffer();
         const auto& size = frameBuffer.getSize();
         Magick::Image image(size.x(), size.y(), format, Magick::CharPixel,
                             colorBuffer);
         image.flip();
         image.write(filename);
+        frameBuffer.unmap();
     }
     catch (Magick::Warning& warning)
     {

--- a/brayns/parameters/ParametersManager.cpp
+++ b/brayns/parameters/ParametersManager.cpp
@@ -79,7 +79,7 @@ bool ParametersManager::isAnyModified() const
 {
     for (AbstractParameters* parameters : _parameterSets)
     {
-        if (parameters->getModified())
+        if (parameters->isModified())
             return true;
     }
     return false;

--- a/brayns/parameters/RenderingParameters.h
+++ b/brayns/parameters/RenderingParameters.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -198,6 +198,17 @@ public:
         _updateValue(_varianceThreshold, value);
     }
 
+    /**
+     * The maximum number of accumulation frames before engine signals to stop
+     * continuation of rendering.
+     *
+     * @sa Engine::continueRendering()
+     */
+    void setMaxAccumFrames(const size_t value)
+    {
+        _updateValue(_maxAccumFrames, value);
+    }
+    size_t getMaxAccumFrames() const { return _maxAccumFrames; }
 protected:
     bool _parse(const po::variables_map& vm) final;
 
@@ -225,6 +236,7 @@ protected:
     bool _headLight;
     bool _dynamicLoadBalancer{false};
     float _varianceThreshold{-1.f};
+    size_t _maxAccumFrames{100};
 
     SERIALIZATION_FRIEND(RenderingParameters)
 };

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -28,12 +28,6 @@ if(BRAYNS_DEFLECT_ENABLED)
 endif()
 
 if(BRAYNS_NETWORKING_ENABLED)
-  # bug in cppcheck while checking json.hpp
-  if(CPPCHECK_VERSION VERSION_LESS 1.78)
-    list(APPEND CPPCHECK_EXTRA_ARGS --error-exitcode=0)
-  endif()
-  list(APPEND CPPCHECK_EXTRA_ARGS
-    --suppress=*:${CMAKE_CURRENT_SOURCE_DIR}/extensions/plugins/json.hpp)
   list(APPEND BRAYNSPLUGINS_HEADERS
     extensions/plugins/ImageGenerator.h
     extensions/plugins/jsonSerialization.h
@@ -42,18 +36,27 @@ if(BRAYNS_NETWORKING_ENABLED)
   list(APPEND BRAYNSPLUGINS_SOURCES
     extensions/plugins/ImageGenerator.cpp
     extensions/plugins/RocketsPlugin.cpp
-    extensions/plugins/staticjson/staticjson.cpp
     extensions/plugins/base64/base64.cpp
+    extensions/plugins/staticjson/staticjson.cpp
   )
   set_source_files_properties(extensions/plugins/staticjson/staticjson.cpp
     PROPERTIES COMPILE_FLAGS -Wno-shadow)
   list(APPEND BRAYNSPLUGINS_PUBLIC_HEADERS extensions/plugins/RocketsPlugin.h)
-  list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PUBLIC Rockets
-    ${LibJpegTurbo_LIBRARIES} ${Magick++_LIBRARIES})
+  list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PUBLIC Rockets)
+  if(LibJpegTurbo_FOUND)
+    list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PRIVATE ${LibJpegTurbo_LIBRARIES})
+  endif()
+  if(BRAYNS_IMAGEMAGICK_ENABLED)
+    list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PRIVATE ${Magick++_LIBRARIES})
+  endif()
+  if(libuv_FOUND)
+    list(APPEND BRAYNSPLUGINS_HEADERS extensions/plugins/SocketListener.h)
+    list(APPEND BRAYNSPLUGINS_SOURCES extensions/plugins/SocketListener.cpp)
+    list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PUBLIC ${libuv_LIBRARIES})
+  endif()
 endif()
 
 if(BRAYNS_OSPRAY_ENABLED)
-  add_definitions(-DBRAYNS_USE_OSPRAY=1)
   add_subdirectory(engines/ospray)
   list(APPEND BRAYNSPLUGINS_LINK_LIBRARIES PUBLIC braynsOSPRayEnginePlugin)
 endif()

--- a/plugins/engines/ospray/OSPRayCamera.cpp
+++ b/plugins/engines/ospray/OSPRayCamera.cpp
@@ -42,7 +42,7 @@ OSPRayCamera::~OSPRayCamera()
 
 void OSPRayCamera::commit()
 {
-    if (!getModified())
+    if (!isModified())
         return;
 
     const auto& position = getPosition();

--- a/plugins/engines/ospray/OSPRayEngine.h
+++ b/plugins/engines/ospray/OSPRayEngine.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -42,14 +42,8 @@ public:
     /** @copydoc Engine::commit */
     void commit() final;
 
-    /** @copydoc Engine::render */
-    void render() final;
-
     /** @copydoc Engine::preRender */
     void preRender() final;
-
-    /** @copydoc Engine::postRender */
-    void postRender() final;
 
     /**
      * Constrain size to multiples of the OSPRay tile size in case of streaming
@@ -62,8 +56,13 @@ public:
 
     /** @copydoc Engine::haveDeflectPixelOp */
     bool haveDeflectPixelOp() const final { return _haveDeflectPixelOp; }
+    FrameBufferPtr createFrameBuffer(const Vector2ui& frameSize,
+                                     FrameBufferFormat frameBufferFormat,
+                                     bool accumulation) final;
+
+    CameraPtr createCamera(CameraType type) final;
+
 private:
-    void _createCamera();
     Renderers _createRenderers();
 
     bool _haveDeflectPixelOp{false};

--- a/plugins/engines/ospray/OSPRayFrameBuffer.cpp
+++ b/plugins/engines/ospray/OSPRayFrameBuffer.cpp
@@ -112,6 +112,7 @@ void OSPRayFrameBuffer::setStreamingParams(const StreamParameters& params,
 
 void OSPRayFrameBuffer::clear()
 {
+    FrameBuffer::clear();
     size_t attributes = OSP_FB_COLOR | OSP_FB_DEPTH;
     if (_accumulation)
         attributes |= OSP_FB_ACCUM | OSP_FB_VARIANCE;
@@ -123,6 +124,7 @@ void OSPRayFrameBuffer::map()
     if (_frameBufferFormat == FrameBufferFormat::none)
         return;
 
+    lock();
     _colorBuffer = (uint8_t*)ospMapFrameBuffer(_frameBuffer, OSP_FB_COLOR);
     _depthBuffer = (float*)ospMapFrameBuffer(_frameBuffer, OSP_FB_DEPTH);
 }
@@ -143,5 +145,7 @@ void OSPRayFrameBuffer::unmap()
         ospUnmapFrameBuffer(_depthBuffer, _frameBuffer);
         _depthBuffer = 0;
     }
+
+    unlock();
 }
 }

--- a/plugins/engines/ospray/OSPRayFrameBuffer.h
+++ b/plugins/engines/ospray/OSPRayFrameBuffer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -24,6 +24,8 @@
 #include <brayns/common/renderer/FrameBuffer.h>
 #include <ospray.h>
 
+#include <mutex>
+
 namespace brayns
 {
 class OSPRayFrameBuffer : public brayns::FrameBuffer
@@ -38,6 +40,8 @@ public:
     void map() final;
     void unmap() final;
 
+    void lock() { _mapMutex.lock(); }
+    void unlock() { _mapMutex.unlock(); }
     uint8_t* getColorBuffer() final { return _colorBuffer; }
     float* getDepthBuffer() final { return _depthBuffer; }
     OSPFrameBuffer impl() { return _frameBuffer; }
@@ -49,6 +53,9 @@ private:
     uint8_t* _colorBuffer;
     float* _depthBuffer;
     OSPPixelOp _pixelOp{nullptr};
+
+    // protect map/unmap vs ospRenderFrame
+    std::mutex _mapMutex;
 };
 }
 #endif // OSPRAYFRAMEBUFFER_H

--- a/plugins/engines/ospray/OSPRayRenderer.cpp
+++ b/plugins/engines/ospray/OSPRayRenderer.cpp
@@ -42,20 +42,18 @@ OSPRayRenderer::~OSPRayRenderer()
     ospRelease(_renderer);
 }
 
-float OSPRayRenderer::render(FrameBufferPtr frameBuffer)
+void OSPRayRenderer::render(FrameBufferPtr frameBuffer)
 {
     auto osprayFrameBuffer =
         std::static_pointer_cast<OSPRayFrameBuffer>(frameBuffer);
     osprayFrameBuffer->lock();
 
-    const auto variance =
-        ospRenderFrame(osprayFrameBuffer->impl(), _renderer,
-                       OSP_FB_COLOR | OSP_FB_DEPTH | OSP_FB_ACCUM);
+    _variance = ospRenderFrame(osprayFrameBuffer->impl(), _renderer,
+                               OSP_FB_COLOR | OSP_FB_DEPTH | OSP_FB_ACCUM);
 
     osprayFrameBuffer->incrementAccumFrames();
     osprayFrameBuffer->markModified();
     osprayFrameBuffer->unlock();
-    return variance;
 }
 
 void OSPRayRenderer::commit()

--- a/plugins/engines/ospray/OSPRayRenderer.h
+++ b/plugins/engines/ospray/OSPRayRenderer.h
@@ -37,9 +37,9 @@ public:
                    ParametersManager& parametersMamager);
     ~OSPRayRenderer();
 
-    float render(FrameBufferPtr frameBuffer) final;
+    void render(FrameBufferPtr frameBuffer) final;
     void commit() final;
-
+    float getVariance() const final { return _variance; }
     void setCamera(CameraPtr camera) final;
 
     PickResult pick(const Vector2f& pickPos) final;
@@ -50,6 +50,7 @@ private:
     std::string _name;
     OSPRayCamera* _camera{nullptr};
     OSPRenderer _renderer;
+    float _variance{std::numeric_limits<float>::max()};
 };
 }
 

--- a/plugins/engines/ospray/OSPRayRenderer.h
+++ b/plugins/engines/ospray/OSPRayRenderer.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -37,7 +37,7 @@ public:
                    ParametersManager& parametersMamager);
     ~OSPRayRenderer();
 
-    void render(FrameBufferPtr frameBuffer) final;
+    float render(FrameBufferPtr frameBuffer) final;
     void commit() final;
 
     void setCamera(CameraPtr camera) final;
@@ -48,9 +48,8 @@ public:
     OSPRenderer impl() const { return _renderer; }
 private:
     std::string _name;
-    OSPRayCamera* _camera;
+    OSPRayCamera* _camera{nullptr};
     OSPRenderer _renderer;
-    float _prevVariance{std::numeric_limits<float>::infinity()};
 };
 }
 

--- a/plugins/engines/ospray/OSPRayScene.cpp
+++ b/plugins/engines/ospray/OSPRayScene.cpp
@@ -617,7 +617,7 @@ void OSPRayScene::commitVolumeData()
     const auto animationFrame = ap.getFrame();
     volumeHandler->setCurrentIndex(animationFrame);
     void* data = volumeHandler->getData();
-    if (data && (ap.getModified() || vp.getModified()))
+    if (data && (ap.isModified() || vp.isModified()))
     {
         for (const auto& renderer : _renderers)
         {

--- a/plugins/extensions/ExtensionPluginFactory.cpp
+++ b/plugins/extensions/ExtensionPluginFactory.cpp
@@ -21,27 +21,9 @@
 #include "ExtensionPluginFactory.h"
 
 #include <plugins/extensions/plugins/ExtensionPlugin.h>
-#if (BRAYNS_USE_NETWORKING)
-#include <plugins/extensions/plugins/RocketsPlugin.h>
-#endif
-#ifdef BRAYNS_USE_DEFLECT
-#include <plugins/extensions/plugins/DeflectPlugin.h>
-#endif
 
 namespace brayns
 {
-ExtensionPluginFactory::ExtensionPluginFactory(
-    ParametersManager& parametersManager BRAYNS_UNUSED)
-{
-#if (BRAYNS_USE_NETWORKING)
-    add(std::make_shared<RocketsPlugin>(parametersManager));
-#endif
-
-#ifdef BRAYNS_USE_DEFLECT
-    add(std::make_shared<DeflectPlugin>(parametersManager));
-#endif
-}
-
 ExtensionPluginFactory::~ExtensionPluginFactory()
 {
     clear();
@@ -66,12 +48,16 @@ void ExtensionPluginFactory::clear()
     _plugins.clear();
 }
 
-void ExtensionPluginFactory::execute(EnginePtr engine,
-                                     KeyboardHandler& keyboardHandler,
-                                     AbstractManipulator& cameraManipulator)
+void ExtensionPluginFactory::preRender(KeyboardHandler& keyboardHandler,
+                                       AbstractManipulator& cameraManipulator)
 {
     for (ExtensionPluginPtr plugin : _plugins)
-        if (!plugin->run(engine, keyboardHandler, cameraManipulator))
-            break;
+        plugin->preRender(keyboardHandler, cameraManipulator);
+}
+
+void ExtensionPluginFactory::postRender()
+{
+    for (ExtensionPluginPtr plugin : _plugins)
+        plugin->postRender();
 }
 }

--- a/plugins/extensions/ExtensionPluginFactory.h
+++ b/plugins/extensions/ExtensionPluginFactory.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -30,11 +30,7 @@ namespace brayns
 class ExtensionPluginFactory
 {
 public:
-    /**
-        Constructs the object and initializes default plugins according to
-        application parameters.
-    */
-    ExtensionPluginFactory(ParametersManager& parametersManager);
+    ExtensionPluginFactory() = default;
 
     ~ExtensionPluginFactory();
 
@@ -55,11 +51,14 @@ public:
      */
     void clear();
 
+    /** Calls preRender() on all registered plugins from Brayns::preRender(). */
+    void preRender(KeyboardHandler& keyboardHandler,
+                   AbstractManipulator& cameraManipulator);
+
     /**
-       Executes code specific to every registered plugin
+     * Calls postRender() on all registered plugins from Brayns::postRender().
      */
-    void execute(EnginePtr engine, KeyboardHandler& keyboardHandler,
-                 AbstractManipulator& cameraManipulator);
+    void postRender();
 
 private:
     ExtensionPlugins _plugins;

--- a/plugins/extensions/plugins/DeflectPlugin.h
+++ b/plugins/extensions/plugins/DeflectPlugin.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -31,11 +31,14 @@ namespace brayns
 class DeflectPlugin : public ExtensionPlugin
 {
 public:
-    DeflectPlugin(ParametersManager& parametersManager);
+    DeflectPlugin(EnginePtr engine, ParametersManager& parametersManager);
 
-    /** @copydoc ExtensionPlugin::run */
-    BRAYNS_API bool run(EnginePtr engine, KeyboardHandler& keyboardHandler,
-                        AbstractManipulator& cameraManipulator) final;
+    /** Handle stream setup and incoming events. */
+    BRAYNS_API void preRender(KeyboardHandler& keyboardHandler,
+                              AbstractManipulator& cameraManipulator) final;
+
+    /** Send rendered frame. */
+    BRAYNS_API void postRender() final;
 
 private:
     struct HandledEvents
@@ -64,6 +67,7 @@ private:
 
     bool _startStream(bool observerOnly);
     void _closeStream();
+    void _setupSocketListener();
 
     void _handleDeflectEvents(Engine& engine, KeyboardHandler& keyboardHandler,
                               AbstractManipulator& cameraManipulator);

--- a/plugins/extensions/plugins/ExtensionPlugin.h
+++ b/plugins/extensions/plugins/ExtensionPlugin.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
@@ -27,10 +27,10 @@
 namespace brayns
 {
 /**
-   Defines the abstract representation of an extension plug-in. What we mean by
-   extension is a set a functionalities that are not provided by the core of
-   the application. For example, exposing a REST interface via HTTP, or
-   streaming images to an distant display.
+ * Defines the abstract representation of an extension plug-in. What we mean by
+ * extension is a set a functionalities that are not provided by the core of the
+ * application. For example, exposing a REST interface via HTTP, or streaming
+ * images to an distant display.
  */
 class ExtensionPlugin
 {
@@ -38,17 +38,23 @@ public:
     virtual ~ExtensionPlugin() = default;
 
     /**
-     * Executes the core functionnalities of the plugin
-     * @return true if other plugins are allowed to continue execution or false
-     *         if control shall be returned to Brayns main loop for e.g.
-     *         rendering a new frame.
+     * Called from Brayns::preRender() to prepare the engine based on the
+     * plugins' need for an upcoming render().
      */
-    BRAYNS_API virtual bool run(EnginePtr _engine,
-                                KeyboardHandler& keyboardHandler,
-                                AbstractManipulator& cameraManipulator) = 0;
+    virtual void preRender(KeyboardHandler& keyboardHandler BRAYNS_UNUSED,
+                           AbstractManipulator& cameraManipulator BRAYNS_UNUSED)
+    {
+    }
 
+    /** Called from Brayns::postRender() after render() has finished. */
+    virtual void postRender() {}
 protected:
-    ExtensionPlugin() = default;
+    ExtensionPlugin(EnginePtr engine)
+        : _engine(engine)
+    {
+    }
+
+    EnginePtr _engine;
 };
 }
 

--- a/plugins/extensions/plugins/RocketsPlugin.cpp
+++ b/plugins/extensions/plugins/RocketsPlugin.cpp
@@ -151,7 +151,7 @@ void RocketsPlugin::_setupRocketsServer()
         try
         {
             _socketListener = std::make_unique<SocketListener>(*_rocketsServer);
-            _socketListener->postReceive = _engine->triggerRender;
+            _socketListener->setPostReceiveCallback(_engine->triggerRender);
             _rocketsServer->setSocketListener(_socketListener.get());
         }
         catch (const std::runtime_error& e)

--- a/plugins/extensions/plugins/RocketsPlugin.cpp
+++ b/plugins/extensions/plugins/RocketsPlugin.cpp
@@ -62,9 +62,6 @@ const std::string METHOD_SNAPSHOT = "snapshot";
 
 const std::string JSON_TYPE = "application/json";
 
-const size_t NB_MAX_MESSAGES = 20; // Maximum number of network messages to read
-                                   // between each rendering loop
-
 std::string hyphenatedToCamelCase(const std::string& hyphenated)
 {
     std::string camel = hyphenated;
@@ -89,8 +86,9 @@ std::string hyphenatedToCamelCase(const std::string& hyphenated)
 
 namespace brayns
 {
-RocketsPlugin::RocketsPlugin(ParametersManager& parametersManager)
-    : ExtensionPlugin()
+RocketsPlugin::RocketsPlugin(EnginePtr engine,
+                             ParametersManager& parametersManager)
+    : ExtensionPlugin(engine)
     , _parametersManager(parametersManager)
 {
     _setupRocketsServer();
@@ -98,40 +96,32 @@ RocketsPlugin::RocketsPlugin(ParametersManager& parametersManager)
 
 RocketsPlugin::~RocketsPlugin()
 {
+    if (_rocketsServer)
+        _rocketsServer->setSocketListener(nullptr);
 }
 
-bool RocketsPlugin::run(EnginePtr engine, KeyboardHandler&,
-                        AbstractManipulator&)
+void RocketsPlugin::preRender(KeyboardHandler&, AbstractManipulator&)
 {
-    if (!_rocketsServer)
-        return true;
-
-    if (_engine != engine)
-    {
-        _engine = engine;
-        _registerEndpoints();
-    }
+    if (!_rocketsServer || _socketListener)
+        return;
 
     try
     {
-        _broadcastWebsocketMessages();
-
-        // In the case of interactions with Jupyter notebooks, HTTP messages are
-        // received in a blocking and sequential manner, meaning that the
-        // subscriber never has more than one message in its queue. In other
-        // words, only one message is processed between each rendering loop. The
-        // following code allows the processing of several messages and performs
-        // rendering after NB_MAX_MESSAGES reads.
-        for (size_t i = 0; i < NB_MAX_MESSAGES; ++i)
-            _rocketsServer->process(0);
+        _rocketsServer->process(0);
     }
     catch (const std::exception& exc)
     {
         BRAYNS_ERROR << "Error while handling HTTP/websocket messages: "
                      << exc.what() << std::endl;
     }
+}
 
-    return true;
+void RocketsPlugin::postRender()
+{
+    if (!_rocketsServer)
+        return;
+
+    _broadcastWebsocketMessages();
 }
 
 std::string RocketsPlugin::_getHttpInterface() const
@@ -157,6 +147,20 @@ void RocketsPlugin::_setupRocketsServer()
 
         _jsonrpcServer.reset(new JsonRpcServer(*_rocketsServer));
 
+#ifdef BRAYNS_USE_LIBUV
+        try
+        {
+            _socketListener = std::make_unique<SocketListener>(*_rocketsServer);
+            _socketListener->postReceive = _engine->triggerRender;
+            _rocketsServer->setSocketListener(_socketListener.get());
+        }
+        catch (const std::runtime_error& e)
+        {
+            BRAYNS_DEBUG << "Failed to setup rockets socket listener: "
+                         << e.what() << std::endl;
+        }
+#endif
+
         _parametersManager.getApplicationParameters().setHttpServerURI(
             _rocketsServer->getURI());
     }
@@ -168,6 +172,7 @@ void RocketsPlugin::_setupRocketsServer()
     }
 
     _setupWebsocket();
+    _registerEndpoints();
     _timer.start();
 }
 
@@ -179,20 +184,15 @@ void RocketsPlugin::_setupWebsocket()
             responses.push_back({i.second(), rockets::ws::Recipient::sender,
                                  rockets::ws::Format::text});
 
-        if (_engine->isReady())
+        const auto image = _imageGenerator.createJPEG(
+            _engine->getFrameBuffer(),
+            _parametersManager.getApplicationParameters().getJpegCompression());
+        if (image.size > 0)
         {
-            const auto image =
-                _imageGenerator.createJPEG(_engine->getFrameBuffer(),
-                                           _parametersManager
-                                               .getApplicationParameters()
-                                               .getJpegCompression());
-            if (image.size > 0)
-            {
-                std::string message;
-                message.assign((const char*)image.data.get(), image.size);
-                responses.push_back({message, rockets::ws::Recipient::sender,
-                                     rockets::ws::Format::binary});
-            }
+            std::string message;
+            message.assign((const char*)image.data.get(), image.size);
+            responses.push_back({message, rockets::ws::Recipient::sender,
+                                 rockets::ws::Format::binary});
         }
         return responses;
     });
@@ -289,6 +289,16 @@ void RocketsPlugin::_handleRPC(const std::string& method,
     _handleSchema(method, buildJsonRpcSchema(method, description));
 }
 
+template <class P, class R>
+void RocketsPlugin::_handleAsyncRPC(
+    const std::string& method, const RpcDocumentation& doc,
+    std::function<void(P, rockets::jsonrpc::AsyncResponse)> action,
+    rockets::jsonrpc::AsyncReceiver::CancelRequestCallback cancel)
+{
+    _jsonrpcServer->bindAsync<P>(method, action, cancel);
+    _handleSchema(method, buildJsonRpcSchema<P, R>(method, doc));
+}
+
 template <class T>
 void RocketsPlugin::_handleObjectSchema(const std::string& endpoint, T& obj)
 {
@@ -309,13 +319,13 @@ void RocketsPlugin::_handleSchema(const std::string& endpoint,
 
 void RocketsPlugin::_registerEndpoints()
 {
-    _handleApplicationParams();
     _handleGeometryParams();
     _handleImageJPEG();
     _handleStreaming();
     _handleVersion();
     _handleVolumeParams();
 
+    _handle(ENDPOINT_APP_PARAMS, _parametersManager.getApplicationParameters());
     _handle(ENDPOINT_FRAME, _parametersManager.getAnimationParameters());
     _handle(ENDPOINT_RENDERING_PARAMS,
             _parametersManager.getRenderingParameters());
@@ -331,15 +341,10 @@ void RocketsPlugin::_registerEndpoints()
     _handle(ENDPOINT_CAMERA, _engine->getCamera());
     _handleGET(ENDPOINT_PROGRESS, _engine->getProgress());
     _handle(ENDPOINT_MATERIAL_LUT, _engine->getScene().getTransferFunction());
-    _handleGET(ENDPOINT_SCENE, _engine->getScene(), [&](const Scene& scene) {
-        return _engine->isReady() && scene.getModified();
-    });
+    _handleGET(ENDPOINT_SCENE, _engine->getScene());
     _handlePUT(ENDPOINT_SCENE, _engine->getScene(),
                [](Scene& scene) { scene.commitMaterials(Action::update); });
-    _handleGET(ENDPOINT_STATISTICS, _engine->getStatistics(),
-               [&](const Statistics& statistics) {
-                   return _engine->isReady() && statistics.getModified();
-               });
+    _handleGET(ENDPOINT_STATISTICS, _engine->getStatistics());
 
     _handleFrameBuffer();
     _handleSimulationHistogram();
@@ -349,17 +354,6 @@ void RocketsPlugin::_registerEndpoints()
     _handleQuit();
     _handleResetCamera();
     _handleSnapshot();
-}
-
-void RocketsPlugin::_handleApplicationParams()
-{
-    auto& params = _parametersManager.getApplicationParameters();
-    auto postUpdate = [this](ApplicationParameters& params_) {
-        if (params_.getFrameExportFolder().empty())
-            _engine->resetFrameNumber();
-    };
-    _handleGET(ENDPOINT_APP_PARAMS, params);
-    _handlePUT(ENDPOINT_APP_PARAMS, params, postUpdate);
 }
 
 void RocketsPlugin::_handleFrameBuffer()
@@ -375,8 +369,7 @@ void RocketsPlugin::_handleGeometryParams()
 {
     auto& params = _parametersManager.getGeometryParameters();
     auto postUpdate = [this](GeometryParameters&) {
-        if (_engine->isReady())
-            _engine->buildScene();
+        _engine->markRebuildScene();
     };
     _handleGET(ENDPOINT_GEOMETRY_PARAMS, params);
     _handlePUT(ENDPOINT_GEOMETRY_PARAMS, params, postUpdate);
@@ -387,8 +380,6 @@ void RocketsPlugin::_handleImageJPEG()
     using namespace rockets::http;
 
     auto func = [&](const Request&) {
-        if (!_engine->isReady())
-            return make_ready_response(Code::NOT_SUPPORTED);
         try
         {
             const auto obj =
@@ -417,7 +408,7 @@ void RocketsPlugin::_handleImageJPEG()
         });
 
     _wsBroadcastOperations[ENDPOINT_IMAGE_JPEG] = [this] {
-        if (_engine->isReady() && _engine->getRenderer().hasNewImage())
+        if (_engine->getFrameBuffer().isModified())
         {
             const auto& params = _parametersManager.getApplicationParameters();
             const auto fps = params.getImageStreamFPS();
@@ -514,8 +505,7 @@ void RocketsPlugin::_handleVolumeParams()
 {
     auto& params = _parametersManager.getVolumeParameters();
     auto postUpdate = [this](VolumeParameters&) {
-        if (_engine->isReady())
-            _engine->buildScene();
+        _engine->markRebuildScene();
     };
     _handleGET(ENDPOINT_VOLUME_PARAMS, params);
     _handlePUT(ENDPOINT_VOLUME_PARAMS, params, postUpdate);
@@ -553,20 +543,37 @@ void RocketsPlugin::_handleSnapshot()
 {
     RpcDocumentation doc{"Make a snapshot of the current view", "settings",
                          "Snapshot settings for quality and size"};
-    _handleRPC<SnapshotParams, ImageGenerator::ImageBase64>(
-        METHOD_SNAPSHOT, doc, [this](const SnapshotParams& params) {
+    _handleAsyncRPC<SnapshotParams, ImageGenerator::ImageBase64>(
+        METHOD_SNAPSHOT, doc,
+        [this](const SnapshotParams& params,
+               rockets::jsonrpc::AsyncResponse callback) {
             try
             {
-                _engine->snapshot(params);
-                return _imageGenerator.createImage(_engine->getFrameBuffer(),
-                                                   params.format,
-                                                   params.quality);
+                auto readyCallback =
+                    [ callback, params,
+                      &imageGenerator = _imageGenerator ](FrameBufferPtr fb)
+                {
+                    try
+                    {
+                        callback(rockets::jsonrpc::Response{to_json(
+                            imageGenerator.createImage(*fb, params.format,
+                                                       params.quality))});
+                    }
+                    catch (const std::runtime_error& e)
+                    {
+                        callback(rockets::jsonrpc::Response{
+                            rockets::jsonrpc::Response::Error{e.what(), -1}});
+                    }
+                };
+                _engine->snapshot(params, readyCallback);
             }
             catch (const std::runtime_error& e)
             {
-                throw rockets::jsonrpc::response_error(e.what(), -1);
+                callback(rockets::jsonrpc::Response{
+                    rockets::jsonrpc::Response::Error{e.what(), -1}});
             }
-        });
+        },
+        [this] { _engine->cancelSnapshot(); });
 }
 
 std::future<rockets::http::Response> RocketsPlugin::_handleCircuitConfigBuilder(

--- a/plugins/extensions/plugins/SocketListener.cpp
+++ b/plugins/extensions/plugins/SocketListener.cpp
@@ -1,0 +1,81 @@
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
+ *                          Daniel.Nachbaur@epfl.ch
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "SocketListener.h"
+
+#include <iostream>
+#include <poll.h>
+
+namespace brayns
+{
+SocketListener::SocketListener(rockets::SocketBasedInterface& interface)
+    : _iface{interface}
+{
+    if (!uvw::Loop::getDefault()->alive())
+        throw std::runtime_error("No libuv loop is alive");
+}
+
+void SocketListener::onNewSocket(const rockets::SocketDescriptor fd,
+                                 const int mode)
+{
+    auto loop = uvw::Loop::getDefault();
+    auto handle = loop->resource<uvw::PollHandle>(fd);
+    _handles.emplace(fd, handle);
+
+    uvw::Flags<uvw::PollHandle::Event> flags;
+    if (mode & POLLIN)
+        flags = flags | uvw::Flags<uvw::PollHandle::Event>(
+                            uvw::PollHandle::Event::READABLE);
+    if (mode & POLLOUT)
+        flags = flags | uvw::Flags<uvw::PollHandle::Event>(
+                            uvw::PollHandle::Event::WRITABLE);
+    handle->on<uvw::PollEvent>([this, fd](const auto& event, auto&) {
+        int flags_ = 0;
+        if (event.flags() & uvw::PollHandle::Event::READABLE)
+            flags_ |= POLLIN;
+        if (event.flags() & uvw::PollHandle::Event::WRITABLE)
+            flags_ |= POLLOUT;
+        _iface.processSocket(fd, flags_);
+
+        if ((event.flags() & uvw::PollHandle::Event::READABLE) && postReceive)
+            postReceive();
+    });
+
+    handle->start(flags);
+}
+
+void SocketListener::onUpdateSocket(const rockets::SocketDescriptor fd,
+                                    const int mode)
+{
+    uvw::Flags<uvw::PollHandle::Event> flags;
+    if (mode & POLLIN)
+        flags = flags | uvw::Flags<uvw::PollHandle::Event>(
+                            uvw::PollHandle::Event::READABLE);
+    if (mode & POLLOUT)
+        flags = flags | uvw::Flags<uvw::PollHandle::Event>(
+                            uvw::PollHandle::Event::WRITABLE);
+    _handles[fd]->start(flags);
+}
+
+void SocketListener::onDeleteSocket(const rockets::SocketDescriptor fd)
+{
+    _handles[fd]->stop();
+    _handles.erase(fd);
+}
+}

--- a/plugins/extensions/plugins/SocketListener.cpp
+++ b/plugins/extensions/plugins/SocketListener.cpp
@@ -53,8 +53,8 @@ void SocketListener::onNewSocket(const rockets::SocketDescriptor fd,
             flags_ |= POLLOUT;
         _iface.processSocket(fd, flags_);
 
-        if ((event.flags() & uvw::PollHandle::Event::READABLE) && postReceive)
-            postReceive();
+        if ((event.flags() & uvw::PollHandle::Event::READABLE) && _postReceive)
+            _postReceive();
     });
 
     handle->start(flags);

--- a/plugins/extensions/plugins/SocketListener.h
+++ b/plugins/extensions/plugins/SocketListener.h
@@ -35,17 +35,21 @@ class SocketListener : public rockets::SocketListener
 public:
     SocketListener(rockets::SocketBasedInterface& interface);
 
+    void setPostReceiveCallback(const std::function<void()>& callback)
+    {
+        _postReceive = callback;
+    }
+
     void onNewSocket(const rockets::SocketDescriptor fd, int mode) final;
 
     void onUpdateSocket(const rockets::SocketDescriptor fd, int mode) final;
 
     void onDeleteSocket(const rockets::SocketDescriptor fd) final;
 
-    std::function<void()> postReceive;
-
 private:
     std::map<rockets::SocketDescriptor, std::shared_ptr<uvw::PollHandle>>
         _handles;
     rockets::SocketBasedInterface& _iface;
+    std::function<void()> _postReceive;
 };
 }

--- a/plugins/extensions/plugins/jsonSerialization.h
+++ b/plugins/extensions/plugins/jsonSerialization.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2017, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
  * Responsible Author: Daniel Nachbaur <daniel.nachbaur@epfl.ch>
  *
@@ -387,6 +387,7 @@ void init(brayns::RenderingParameters* r, ObjectHandler* h)
     h->add_property("head_light", &r->_headLight, Flags::Optional);
     h->add_property("variance_threshold", &r->_varianceThreshold,
                     Flags::Optional);
+    h->add_property("max_accum_frames", &r->_maxAccumFrames, Flags::Optional);
     h->add_property("background_color", Vector3fArray(r->_backgroundColor),
                     Flags::Optional);
     h->add_property("detection_distance", &r->_detectionDistance,

--- a/tests/webAPI.cpp
+++ b/tests/webAPI.cpp
@@ -56,6 +56,10 @@ public:
         const char* argv[] = {app, "--http-server", ":0"};
         const int argc = sizeof(argv) / sizeof(char*);
         brayns.reset(new brayns::Brayns(argc, argv));
+        brayns->createPlugins();
+        brayns->getParametersManager()
+            .getApplicationParameters()
+            .setImageStreamFPS(0);
         brayns->render();
 
         const auto uri = brayns->getParametersManager()


### PR DESCRIPTION
* use libuv and uvw as an event-loop
* extend Brayns to use threaded and event-driven rendering in braynsService
* braynsViewer remains untouched in its behavior
* introduce cancel for snapshots