### PR TITLE
Add Topology Viewer plugin with action interface

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -81,7 +81,6 @@ namespace brayns
 struct Brayns::Impl
 {
     EnginePtr _engine;
-    std::shared_ptr<ActionInterface> _actionInterface;
 
     Impl(int argc, const char** argv, ParametersManager& parametersManager,
          ExtensionPluginFactory& extensionPluginFactory)
@@ -108,25 +107,6 @@ struct Brayns::Impl
 
         if (!isAsyncMode())
             _finishLoadScene();
-    }
-
-    void createPlugins()
-    {
-#if (BRAYNS_USE_NETWORKING)
-        auto rocketsPlugin =
-            std::make_shared<RocketsPlugin>(_engine, _parametersManager);
-        _extensionPluginFactory.add(rocketsPlugin);
-        _actionInterface = rocketsPlugin;
-#endif
-#ifdef BRAYNS_USE_DEFLECT
-        _extensionPluginFactory.add(
-            std::make_shared<DeflectPlugin>(_engine, _parametersManager));
-#endif
-#ifdef BRAYNS_USE_TOPOLOGY_VIEWER_PLUGIN
-        _extensionPluginFactory.add(
-            std::make_shared<TopologyViewerPlugin>(_engine,
-                                                   _parametersManager));
-#endif
     }
 
     bool preRender()
@@ -1273,8 +1253,15 @@ bool Brayns::render()
 
 void Brayns::createPlugins()
 {
-    _impl->createPlugins();
-    _actionInterface = _impl->_actionInterface;
+#if (BRAYNS_USE_NETWORKING)
+    _actionInterface = addPlugin<RocketsPlugin>();
+#endif
+#ifdef BRAYNS_USE_DEFLECT
+    addPlugin<DeflectPlugin>();
+#endif
+#ifdef BRAYNS_USE_TOPOLOGY_VIEWER_PLUGIN
+    addPlugin<TopologyViewerPlugin>();
+#endif
 }
 
 bool Brayns::preRender()

--- a/plugins/extensions/plugins/DeflectPlugin.cpp
+++ b/plugins/extensions/plugins/DeflectPlugin.cpp
@@ -52,7 +52,8 @@ std::future<T> make_ready_future(const T value)
 namespace brayns
 {
 DeflectPlugin::DeflectPlugin(EnginePtr engine,
-                             ParametersManager& parametersManager)
+                             ParametersManager& parametersManager,
+                             ActionInterface* actionInterface BRAYNS_UNUSED)
     : ExtensionPlugin(engine)
     , _appParams{parametersManager.getApplicationParameters()}
     , _params{parametersManager.getStreamParameters()}

--- a/plugins/extensions/plugins/DeflectPlugin.h
+++ b/plugins/extensions/plugins/DeflectPlugin.h
@@ -31,7 +31,8 @@ namespace brayns
 class DeflectPlugin : public ExtensionPlugin
 {
 public:
-    DeflectPlugin(EnginePtr engine, ParametersManager& parametersManager);
+    DeflectPlugin(EnginePtr engine, ParametersManager& parametersManager,
+                  ActionInterface* actionInterface);
 
     /** Handle stream setup and incoming events. */
     BRAYNS_API void preRender(KeyboardHandler& keyboardHandler,

--- a/plugins/extensions/plugins/RocketsPlugin.cpp
+++ b/plugins/extensions/plugins/RocketsPlugin.cpp
@@ -104,7 +104,8 @@ inline bool from_json(T& obj, const std::string& json, F postUpdateFunc = [] {})
 }
 
 RocketsPlugin::RocketsPlugin(EnginePtr engine,
-                             ParametersManager& parametersManager)
+                             ParametersManager& parametersManager,
+                             ActionInterface* actionInterface BRAYNS_UNUSED)
     : ExtensionPlugin(engine)
     , _parametersManager(parametersManager)
 {

--- a/plugins/extensions/plugins/RocketsPlugin.h
+++ b/plugins/extensions/plugins/RocketsPlugin.h
@@ -47,7 +47,8 @@ struct RpcDocumentation;
 class RocketsPlugin : public ExtensionPlugin, public ActionInterface
 {
 public:
-    RocketsPlugin(EnginePtr engine, ParametersManager& parametersManager);
+    RocketsPlugin(EnginePtr engine, ParametersManager& parametersManager,
+                  ActionInterface* ActionInterface);
     ~RocketsPlugin();
 
     /**


### PR DESCRIPTION
Uses the templated addPlugin function for all plugins in Brayns and
removes the duplicate createPlugins function and _actionInterface
variable in the Impl class.