### PR TITLE
Trigger always one frame after braynsService is setup'd

### DIFF
--- a/apps/BraynsService/main.cpp
+++ b/apps/BraynsService/main.cpp
@@ -48,6 +48,9 @@ public:
         _setupRenderThread();
 
         _brayns.loadPlugins();
+
+        // launch first frame; after that, only events will trigger that
+        _eventRendering->start();
     }
 
     void run()


### PR DESCRIPTION
This fixes the missing start of Deflect streaming when specified with
DEFLECT_HOST.