### PR TITLE
Set default camera only on first scene build

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -302,6 +302,12 @@ struct Brayns::Impl : public PluginAPI
             _loadScene();
 
         promise.set_value();
+
+        const auto frameSize = Vector2f(_engine->getFrameBuffer().getSize());
+
+        auto& camera = _engine->getCamera();
+        camera.setInitialState(_engine->getScene().getWorldBounds());
+        camera.setAspectRatio(frameSize.x() / frameSize.y());
     }
 
     bool preRender(const RenderInput& renderInput)
@@ -358,6 +364,7 @@ struct Brayns::Impl : public PluginAPI
     {
         return *_cameraManipulator;
     }
+    Camera& getCamera() final { return _engine->getCamera(); }
     ActionInterface* getActionInterface() final
     {
         return _actionInterface.get();
@@ -432,9 +439,6 @@ private:
     {
         if (_dataLoadingFuture.valid())
             _dataLoadingFuture.get();
-
-        // Set default camera according to scene bounding box
-        _engine->setDefaultCamera();
 
         // Set default epsilon according to scene bounding box
         _engine->setDefaultEpsilon();

--- a/brayns/common/camera/Camera.cpp
+++ b/brayns/common/camera/Camera.cpp
@@ -77,6 +77,21 @@ void Camera::setInitialState(const Vector3f& position, const Vector3f& target,
     set(position, target, upVector);
 }
 
+BRAYNS_API void Camera::setInitialState(const Boxf& boundingBox)
+{
+    const Vector3f& target = boundingBox.getCenter();
+    const Vector3f& diag = boundingBox.getSize();
+    Vector3f position = target;
+    position.z() += diag.find_max();
+
+    const Vector3f up = Vector3f(0.f, 1.f, 0.f);
+    setInitialState(position, target, up);
+
+    BRAYNS_INFO << "World bounding box: " << boundingBox << std::endl;
+    BRAYNS_INFO << "World center      : " << boundingBox.getCenter()
+                << std::endl;
+}
+
 void Camera::reset()
 {
     set(_initialPosition, _initialTarget, _initialUp);

--- a/brayns/common/camera/Camera.h
+++ b/brayns/common/camera/Camera.h
@@ -62,6 +62,8 @@ public:
     BRAYNS_API void setInitialState(const Vector3f& position,
                                     const Vector3f& target, const Vector3f& up);
 
+    BRAYNS_API void setInitialState(const Boxf& boundingBox);
+
     /**
        Gets camera type
        @return The type of camera (Perpective, Stereo, etc)

--- a/brayns/common/engine/Engine.cpp
+++ b/brayns/common/engine/Engine.cpp
@@ -62,26 +62,6 @@ void Engine::reshape(const Vector2ui& frameSize)
     _camera->commit();
 }
 
-void Engine::setDefaultCamera()
-{
-    const Vector2i& frameSize = _frameBuffer->getSize();
-
-    const Boxf& worldBounds = _scene->getWorldBounds();
-    const Vector3f& target = worldBounds.getCenter();
-    const Vector3f& diag = worldBounds.getSize();
-    Vector3f position = target;
-    position.z() += diag.find_max();
-
-    const Vector3f up = Vector3f(0.f, 1.f, 0.f);
-    _camera->setInitialState(position, target, up);
-    _camera->setAspectRatio(static_cast<float>(frameSize.x()) /
-                            static_cast<float>(frameSize.y()));
-
-    BRAYNS_INFO << "World bounding box: " << worldBounds << std::endl;
-    BRAYNS_INFO << "World center      : " << worldBounds.getCenter()
-                << std::endl;
-}
-
 void Engine::setDefaultEpsilon()
 {
     float epsilon = _parametersManager.getRenderingParameters().getEpsilon();

--- a/brayns/common/engine/Engine.h
+++ b/brayns/common/engine/Engine.h
@@ -90,11 +90,6 @@ public:
     void reshape(const Vector2ui& frameSize);
 
     /**
-       Sets default camera according to scene bounding box
-    */
-    void setDefaultCamera();
-
-    /**
        Sets default epsilon to scene bounding box
     */
     void setDefaultEpsilon();

--- a/brayns/pluginapi/PluginAPI.h
+++ b/brayns/pluginapi/PluginAPI.h
@@ -45,5 +45,8 @@ public:
 
     /** @return access to the camera manipulator of Brayns. */
     virtual AbstractManipulator& getCameraManipulator() = 0;
+
+    /** @return access to the camera of Brayns. */
+    virtual Camera& getCamera() = 0;
 };
 }


### PR DESCRIPTION
This solves the crash bug where we got invalid bounding box and
camera if the scene was empty. It also give access to the camera
through the plugin API.