### PR TITLE
Throw exception if model is empty

### DIFF
--- a/brayns/common/scene/Model.cpp
+++ b/brayns/common/scene/Model.cpp
@@ -113,6 +113,9 @@ uint64_t Model::addCone(const size_t materialId, const Cone& cone)
 
 void Model::addModel(ModelPtr model, const Transformations& transform)
 {
+    if (model->empty())
+        throw std::runtime_error("Empty models not supported.");
+
     _bounds.merge(model->getBounds());
     _models.push_back({std::move(model), transform});
     _modelsDirty = true;

--- a/brayns/common/scene/Model.cpp
+++ b/brayns/common/scene/Model.cpp
@@ -82,7 +82,8 @@ ModelDescriptor& ModelDescriptor::operator=(const ModelParams& rhs)
 bool Model::empty() const
 {
     return _spheres.empty() && _cylinders.empty() && _cones.empty() &&
-           _trianglesMeshes.empty() && _models.empty();
+           _trianglesMeshes.empty() && _models.empty() &&
+           _sdf.geometries.empty();
 }
 
 uint64_t Model::addSphere(const size_t materialId, const Sphere& sphere)

--- a/brayns/common/scene/Model.h
+++ b/brayns/common/scene/Model.h
@@ -192,6 +192,7 @@ public:
      *
      * Note that model is 'moved', so this model will own the added model from
      * now on.
+     * @throw std::runtime_error if model is empty
      */
     BRAYNS_API void addModel(ModelPtr model, const Transformations& transform);
 

--- a/brayns/common/scene/Scene.cpp
+++ b/brayns/common/scene/Scene.cpp
@@ -111,6 +111,9 @@ void Scene::clearLights()
 
 size_t Scene::addModel(ModelDescriptorPtr model)
 {
+    if (model->getModel().empty())
+        throw std::runtime_error("Empty models not supported.");
+
     model->getModel().buildBoundingBox();
     model->getModel().commit();
 

--- a/brayns/common/scene/Scene.h
+++ b/brayns/common/scene/Scene.h
@@ -123,6 +123,7 @@ public:
 
     /**
         Adds a model to the scene
+        @throw std::runtime_error if model is empty
       */
     BRAYNS_API size_t addModel(ModelDescriptorPtr model);
 


### PR DESCRIPTION
Empty models cause issues so throw an exception if they are added to the scene.