### PR TITLE
Give precedence to later added loaders

### DIFF
--- a/brayns/common/loader/LoaderRegistry.cpp
+++ b/brayns/common/loader/LoaderRegistry.cpp
@@ -29,7 +29,7 @@ namespace brayns
 {
 void LoaderRegistry::registerLoader(LoaderInfo loaderInfo)
 {
-    _loaders.push_back(loaderInfo);
+    _loaders.insert(_loaders.begin(), loaderInfo);
 }
 
 bool LoaderRegistry::isSupported(const std::string& type) const


### PR DESCRIPTION
This is to make sure that loaders added by plugins are matched before built-in ones.