### PR TITLE
Call plugin prerender only with locked mutex

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -184,11 +184,11 @@ struct Brayns::Impl : public PluginAPI
 #endif
         }
 
-        _extensionPluginFactory.preRender();
-
         std::unique_lock<std::mutex> lock{_renderMutex, std::defer_lock};
         if (!lock.try_lock())
             return false;
+
+        _extensionPluginFactory.preRender();
 
         auto& scene = _engine->getScene();
         scene.commit();


### PR DESCRIPTION
Since the plugin can add and remove models in the scene we need to make sure it is not running when Brayns is rendering.