### PR TITLE
Fixed material issue in the mesh loader

### DIFF
--- a/brayns/io/MeshLoader.cpp
+++ b/brayns/io/MeshLoader.cpp
@@ -240,7 +240,9 @@ void MeshLoader::_postLoad(const aiScene* aiScene, Model& model,
     for (size_t m = 0; m < aiScene->mNumMeshes; ++m)
     {
         auto mesh = aiScene->mMeshes[m];
-        auto& triangleMeshes = model.getTrianglesMeshes()[mesh->mMaterialIndex];
+        auto id =
+            (materialId != NO_MATERIAL ? materialId : mesh->mMaterialIndex);
+        auto& triangleMeshes = model.getTrianglesMeshes()[id];
 
         nbVertices += mesh->mNumVertices;
         triangleMeshes.vertices.reserve(nbVertices);


### PR DESCRIPTION
Color scheme management must eventually be removed from any loader. Meshes must be loaded as is, and it's the role of the application to change the materials a posteriori (if required by the usecase)