### PR TITLE
Changed viewport to floats in order to increase browser compatibility

### DIFF
--- a/brayns/parameters/ApplicationParameters.h
+++ b/brayns/parameters/ApplicationParameters.h
@@ -50,10 +50,11 @@ public:
     /** Runtime plugins to load in Brayns::loadPlugins. */
     const std::vector<PluginParam>& getPlugins() const { return _plugins; }
     /** window size */
-    const Vector2ui& getWindowSize() const { return _windowSize; }
+    const Vector2ui getWindowSize() const { return Vector2ui(_windowSize); }
     void setWindowSize(const Vector2ui& size)
     {
-        _updateValue(_windowSize, size);
+        Vector2f value(size);
+        _updateValue(_windowSize, value);
     }
     /** Benchmarking */
     bool isBenchmarking() const { return _benchmarking; }
@@ -89,7 +90,6 @@ public:
     }
 
     bool getParallelRendering() const { return _parallelRendering; }
-
     const std::string& getHttpServerURI() const { return _httpServerURI; }
     void setHttpServerURI(const std::string& httpServerURI)
     {
@@ -98,13 +98,12 @@ public:
 
     const strings& getInputPaths() const { return _inputPaths; }
     po::positional_options_description& posArgs() { return _positionalArgs; }
-
 protected:
     void parse(const po::variables_map& vm) final;
 
     strings _pluginsRaw;
     std::vector<PluginParam> _plugins;
-    Vector2ui _windowSize;
+    Vector2f _windowSize;
     bool _benchmarking;
     size_t _jpegCompression;
     strings _filters;

--- a/plugins/RocketsPlugin/jsonSerialization.h
+++ b/plugins/RocketsPlugin/jsonSerialization.h
@@ -408,8 +408,7 @@ inline void init(brayns::ApplicationParameters* a, ObjectHandler* h)
                     Flags::Optional);
     h->add_property("synchronous_mode", &a->_synchronousMode, Flags::Optional);
     h->add_property("image_stream_fps", &a->_imageStreamFPS, Flags::Optional);
-    h->add_property("viewport", Vector2uiArray(a->_windowSize),
-                    Flags::Optional);
+    h->add_property("viewport", Vector2fArray(a->_windowSize), Flags::Optional);
     h->set_flags(Flags::DisallowUnknownKey);
 }
 


### PR DESCRIPTION
Some browsers process viewport size as floats rather than uint. Brayns now exposes floats through the ws API but still uses unsigned int internally.