### PR TITLE
Fix segfault when using Viewer and browser UI

### DIFF
--- a/apps/ui/BaseWindow.cpp
+++ b/apps/ui/BaseWindow.cpp
@@ -304,8 +304,8 @@ void BaseWindow::display()
 
         if (buffer)
         {
-            glDrawPixels(_windowSize.x(), _windowSize.y(), format, type,
-                         buffer);
+            glDrawPixels(renderOutput.frameSize.x(), renderOutput.frameSize.y(),
+                         format, type, buffer);
         }
     }
     else

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -398,6 +398,9 @@ struct Brayns::Impl : public PluginAPI
             const size_t size = frameSize.x() * frameSize.y();
             renderOutput.depthBuffer.assign(depthBuffer, depthBuffer + size);
         }
+
+        renderOutput.frameSize = frameSize;
+
         frameBuffer.unmap();
 
         postRender();

--- a/brayns/common/types.h
+++ b/brayns/common/types.h
@@ -374,6 +374,7 @@ struct RenderInput
 
 struct RenderOutput
 {
+    Vector2i frameSize;
     uint8_ts colorBuffer;
     floats depthBuffer;
     FrameBufferFormat colorBufferFormat;


### PR DESCRIPTION
When the browser is connecting to Brayns it changes the viewport size in preRender(). Since the Viewer is unaware of this change then the Viewer will try to draw the resized buffer with an incorrect viewport size. If the buffer is shrunk then this can lead to a segfault. Now instead, the actual width and height of the buffer is stored when rendering and then used when the Viewer is drawing.