### PR TITLE
Remove model bounding box as per-instance bounding box is enough

### DIFF
--- a/brayns/parameters/RenderingParameters.cpp
+++ b/brayns/parameters/RenderingParameters.cpp
@@ -41,12 +41,6 @@ const std::array<std::string, 8> RENDERER_NAMES = {
 
 const std::array<std::string, 4> CAMERA_TYPE_NAMES = {
     {"perspective", "orthographic", "panoramic", "clippedperspective"}};
-
-const std::array<std::string, 4> STEREO_MODES = {
-    {"none", "left", "right", "side-by-side"}};
-
-const std::array<std::string, 3> SHADING_TYPES = {
-    {"none", "diffuse", "electron"}};
 }
 
 namespace brayns

--- a/plugins/engines/ospray/OSPRayScene.cpp
+++ b/plugins/engines/ospray/OSPRayScene.cpp
@@ -149,18 +149,6 @@ void OSPRayScene::commit()
             instancesBounds.merge(transformBox(modelBounds, instanceTransform));
         }
 
-        if (modelDescriptor->getBoundingBox())
-        {
-            Transformation instancesTransform;
-            instancesTransform.setTranslation(instancesBounds.getCenter() -
-                                              modelBounds.getCenter());
-            instancesTransform.setScale(instancesBounds.getSize() /
-                                        modelBounds.getSize());
-
-            addInstance(_rootModel, impl.getBoundingBoxModel(),
-                        instancesTransform);
-        }
-
         impl.logInformation();
     }
     BRAYNS_DEBUG << "Committing root models" << std::endl;


### PR DESCRIPTION
This fixes wrong bounding boxes when using rotation and/or scale on the model.