### PR TITLE
Update current renderer type directly on set-renderer RPC

### DIFF
--- a/brayns/common/utils/Utils.cpp
+++ b/brayns/common/utils/Utils.cpp
@@ -106,7 +106,10 @@ archive* _openArchive(const std::string& filename)
     }
     if (archive_read_open_filename(archive, filename.c_str(), 10240) ==
         ARCHIVE_OK)
+    {
         return archive;
+    }
+    archive_read_free(archive);
     return nullptr;
 }
 

--- a/plugins/RocketsPlugin/RocketsPlugin.cpp
+++ b/plugins/RocketsPlugin/RocketsPlugin.cpp
@@ -787,15 +787,17 @@ public:
     void _handleRenderer()
     {
         auto& params = _parametersManager.getRenderingParameters();
-        auto preUpdate = [](const RenderingParameters& obj) {
-            return std::find(obj.getRenderers().begin(),
-                             obj.getRenderers().end(),
-                             obj.getCurrentRenderer()) !=
-                   obj.getRenderers().end();
+        auto preUpdate = [](const auto& rp) {
+            return std::find(rp.getRenderers().begin(), rp.getRenderers().end(),
+                             rp.getCurrentRenderer()) !=
+                   rp.getRenderers().end();
+        };
+        auto postUpdate = [& renderer = _engine->getRenderer()](auto& rp)
+        {
+            renderer.setCurrentType(rp.getCurrentRenderer());
         };
         _handleGET(ENDPOINT_RENDERER, params);
-        _handlePUT(ENDPOINT_RENDERER, params, preUpdate,
-                   std::function<void(RenderingParameters&)>());
+        _handlePUT(ENDPOINT_RENDERER, params, preUpdate, postUpdate);
     }
 
     void _handleSchemaRPC()


### PR DESCRIPTION
This fixes an issue where a following get-renderer-params RPC is issued and the
current type is only updated in the preRender() loop.