### PR TITLE
Fix race condition causing deformed snapshots when using UI.

### DIFF
--- a/brayns/common/PropertyObject.h
+++ b/brayns/common/PropertyObject.h
@@ -118,6 +118,24 @@ public:
         return types;
     }
 
+    /** Clear all current properties and clone new properties from object  */
+    void clonePropertiesFrom(const PropertyObject& obj)
+    {
+        _currentType = obj._currentType;
+        _properties.clear();
+        for (const auto& kv : obj._properties)
+        {
+            const auto& key = kv.first;
+            const auto& properties = kv.second.getProperties();
+
+            PropertyMap propertyMapClone;
+            for (const auto& property : properties)
+                propertyMapClone.setProperty(*property);
+
+            _properties[key] = propertyMapClone;
+        }
+    }
+
 protected:
     std::string _currentType;
     std::map<std::string, PropertyMap> _properties;

--- a/plugins/RocketsPlugin/SnapshotTask.h
+++ b/plugins/RocketsPlugin/SnapshotTask.h
@@ -60,16 +60,24 @@ public:
                                                 FrameBufferFormat::rgba_i8,
                                                 true))
         , _camera(engine.createCamera())
-        , _renderer(engine.createRenderer(
-              _params.animParams
-                  ? *_params.animParams
-                  : engine.getParametersManager().getAnimationParameters(),
-              _params.renderingParams
-                  ? *_params.renderingParams
-                  : engine.getParametersManager().getRenderingParameters()))
         , _scene(engine.createScene(engine.getParametersManager()))
         , _imageGenerator(imageGenerator)
     {
+        if (_params.animParams == nullptr)
+        {
+            _params.animParams = std::make_unique<AnimationParameters>(
+                engine.getParametersManager().getAnimationParameters());
+        }
+
+        if (_params.renderingParams == nullptr)
+        {
+            _params.renderingParams = std::make_unique<RenderingParameters>(
+                engine.getParametersManager().getRenderingParameters());
+        }
+
+        _renderer = engine.createRenderer(*_params.animParams,
+                                          *_params.renderingParams);
+
         const auto& renderer = engine.getRenderer();
         _renderer->setCurrentType(renderer.getCurrentType());
         _renderer->setProperties(renderer.getPropertyMap());
@@ -80,7 +88,10 @@ public:
             _camera->setProperties(engine.getCamera().getPropertyMap());
         }
         else
+        {
             *_camera = engine.getCamera();
+            _camera->clonePropertiesFrom(engine.getCamera());
+        }
 
         *_scene = engine.getScene();
     }


### PR DESCRIPTION
The problem was that the 'aspect' property in the camera was updated concurrently by both the snapshot renderer and the UI. This sometimes made the snapshot image stretched or compressed if the UI and the snapshot were using different aspect ratios. Now all the camera properties are cloned instead of shared when taking snapshots which fixes the issue.