### PR TITLE
Fix sporadic segfault

### DIFF
--- a/plugins/engines/ospray/OSPRayRenderer.cpp
+++ b/plugins/engines/ospray/OSPRayRenderer.cpp
@@ -75,12 +75,8 @@ void OSPRayRenderer::commit()
     {
         ospSetData(_renderer, "lights", scene->lightData());
 
-        if (_scene->getSimulationHandler())
-        {
+        if (scene->simulationData())
             ospSetData(_renderer, "simulationData", scene->simulationData());
-            ospSet1i(_renderer, "simulationDataSize",
-                     _scene->getSimulationHandler()->getFrameSize());
-        }
 
         // Transfer function Diffuse colors
         ospSetData(_renderer, "transferFunctionDiffuseData",
@@ -89,10 +85,6 @@ void OSPRayRenderer::commit()
         // Transfer function emission data
         ospSetData(_renderer, "transferFunctionEmissionData",
                    scene->transferFunctionEmissionData());
-
-        // Transfer function size
-        ospSet1i(_renderer, "transferFunctionSize",
-                 _scene->getTransferFunction().getDiffuseColors().size());
 
         // Transfer function range
         ospSet1f(_renderer, "transferFunctionMinValue",

--- a/plugins/engines/ospray/ispc/render/ParticleRenderer.h
+++ b/plugins/engines/ospray/ispc/render/ParticleRenderer.h
@@ -40,10 +40,8 @@ public:
 
 private:
     ospray::Ref<ospray::Data> _simulationData;
-    ospray::uint64 _simulationDataSize;
     ospray::Ref<ospray::Data> _transferFunctionDiffuseData;
     ospray::Ref<ospray::Data> _transferFunctionEmissionData;
-    ospray::uint32 _transferFunctionSize;
     int _randomNumber;
 };
 

--- a/plugins/engines/ospray/ispc/render/SimulationRenderer.h
+++ b/plugins/engines/ospray/ispc/render/SimulationRenderer.h
@@ -57,10 +57,8 @@ private:
     int _randomNumber;
 
     ospray::Ref<ospray::Data> _simulationData;
-    ospray::uint64 _simulationDataSize;
     ospray::Ref<ospray::Data> _transferFunctionDiffuseData;
     ospray::Ref<ospray::Data> _transferFunctionEmissionData;
-    ospray::int32 _transferFunctionSize;
     float _transferFunctionMinValue;
     float _transferFunctionRange;
     ospray::int32 _volumeSamplesPerRay;


### PR DESCRIPTION
Sometimes the asynchronous simulation data is not loaded in time causing a segfault since the size of the data is set but not the actual data. Now the size is read from the actual data which should make these inconsistencies disappear. The same is now also done for transfer functions.