### PR TITLE
Use plugin name as first argument for extension plugins.

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -147,10 +147,12 @@ struct Brayns::Impl : public PluginAPI
                         "brayns_plugin_create()");
                 }
 
-                // Build argc, argv
-                const int argc = pluginParam.arguments.size();
-                std::vector<char*> argv(argc, nullptr);
                 std::vector<std::string> tmpArgs = pluginParam.arguments;
+                tmpArgs.insert(tmpArgs.begin(), pluginName);
+
+                // Build argc, argv
+                const int argc = tmpArgs.size();
+                std::vector<char*> argv(argc, nullptr);
 
                 for (int i = 0; i < argc; i++)
                     argv[i] = &tmpArgs[i].front();

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -147,7 +147,7 @@ struct Brayns::Impl : public PluginAPI
                         "brayns_plugin_create()");
                 }
 
-                std::vector<std::string> tmpArgs = pluginParam.arguments;
+                auto tmpArgs = pluginParam.arguments;
                 tmpArgs.insert(tmpArgs.begin(), pluginName);
 
                 // Build argc, argv


### PR DESCRIPTION
This makes it conform with how argc/argv usually works. It will also make it easier for plugins that use boost and similar for parsing input arguments.