### PR TITLE
Fix clip planes after changing from float to double

### DIFF
--- a/engines/ospray/OSPRayCamera.cpp
+++ b/engines/ospray/OSPRayCamera.cpp
@@ -53,8 +53,9 @@ void OSPRayCamera::commit()
     // Clip planes
     if (!_clipPlanes.empty())
     {
+        const auto clipPlanes = convertVectorToFloat(_clipPlanes);
         auto clipPlaneData =
-            ospNewData(_clipPlanes.size(), OSP_FLOAT4, _clipPlanes.data());
+            ospNewData(clipPlanes.size(), OSP_FLOAT4, clipPlanes.data());
         ospSetData(_camera, "clipPlanes", clipPlaneData);
         ospRelease(clipPlaneData);
     }

--- a/engines/ospray/utils.h
+++ b/engines/ospray/utils.h
@@ -40,4 +40,20 @@ void addInstance(OSPModel rootModel, OSPModel modelToAdd,
                  const Transformation& transform);
 void addInstance(OSPModel rootModel, OSPModel modelToAdd,
                  const ospcommon::affine3f& affine);
+
+/** Helper to convert a vector of double tuples to a vector of float tuples. */
+template <size_t S>
+std::vector<std::array<float, S>> convertVectorToFloat(
+    const std::vector<std::array<double, S>>& input)
+{
+    std::vector<std::array<float, S>> output;
+    output.reserve(input.size());
+    for (const auto& value : input)
+    {
+        std::array<float, S> converted;
+        std::copy(value.data(), value.data() + S, converted.data());
+        output.push_back(converted);
+    }
+    return output;
+}
 }


### PR DESCRIPTION
OSPRay only supports floats for data arrays, hence we have to convert the
vector of doubles to floats.