### PR TITLE
Support batch JSON-RPC in python client

### DIFF
--- a/plugins/RocketsPlugin/RocketsPlugin.cpp
+++ b/plugins/RocketsPlugin/RocketsPlugin.cpp
@@ -761,6 +761,8 @@ public:
                              (std::function<brayns::Version()>)[] {
                                  return brayns::Version();
                              });
+
+        _handleSchema(ENDPOINT_VERSION, version.getSchema());
     }
 
     void _handleVolumeParams()

--- a/python/brayns/utils.py
+++ b/python/brayns/utils.py
@@ -42,6 +42,8 @@ WSS_PREFIX = 'wss://'
 
 WS_PATH = '/ws'
 
+SCHEMA_ENDPOINT = '/schema'
+
 
 class Status(object):
     """Holds the execution status of an HTTP request."""

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.7.0.dev0
+version = 0.7.0.dev1
 name = brayns
 summary = Brayns python API
 home-page = https://github.com/BlueBrain/Brayns


### PR DESCRIPTION
This is used to batch request all schemas to reduce the number of roundtrips
which boosts the performance of the initial connect (closes #502).