### PR TITLE
 Do not mark scene as modified when adding/removing model

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -483,6 +483,7 @@ private:
 
         scene.saveToCacheFile();
         scene.buildEnvironmentMap();
+        scene.markModified();
     }
 
 #if (BRAYNS_USE_BRION)
@@ -535,6 +536,7 @@ private:
                 scene.setSimulationHandler(simulationHandler);
             }
             scene.addModel(model);
+            scene.markModified();
         }
     }
 
@@ -561,6 +563,7 @@ private:
 
         const servus::URI uri(filename);
         scene.addModel(circuitLoader.importCircuit(uri, targets, report));
+        scene.markModified();
     }
 #endif // BRAYNS_USE_BRION
 
@@ -576,6 +579,7 @@ private:
         molecularSystemReader.setProgressCallback(progressUpdate);
         const auto fileName = geometryParameters.getMolecularSystemConfig();
         scene.addModel(molecularSystemReader.importFromFile(fileName));
+        scene.markModified();
     }
 
     void _setupCameraManipulator(const CameraMode mode)

--- a/brayns/common/scene/Scene.cpp
+++ b/brayns/common/scene/Scene.cpp
@@ -241,7 +241,7 @@ bool Scene::empty() const
 size_t Scene::addClipPlane(const Plane& plane)
 {
     auto clipPlane = std::make_shared<ClipPlane>(plane);
-    clipPlane->onModified([&](const BaseObject&){ markModified(); });
+    clipPlane->onModified([&](const BaseObject&) { markModified(); });
     _clipPlanes.emplace_back(std::move(clipPlane));
     markModified();
     return _clipPlanes.back()->getID();

--- a/brayns/common/scene/Scene.h
+++ b/brayns/common/scene/Scene.h
@@ -34,7 +34,6 @@ SERIALIZATION_ACCESS(Scene)
 
 namespace brayns
 {
-
 /**
 
    Scene object
@@ -171,11 +170,7 @@ public:
     /**
        @return the clip planes
     */
-    const ClipPlanes& getClipPlanes() const
-    {
-        return _clipPlanes;
-    }
-
+    const ClipPlanes& getClipPlanes() const { return _clipPlanes; }
     /**
         Returns the simulutation handler
     */

--- a/brayns/common/scene/Scene.h
+++ b/brayns/common/scene/Scene.h
@@ -131,8 +131,9 @@ public:
     /**
         Removes a model from the scene
         @param id id of the model (descriptor)
+        @return True if model was found and removed, false otherwise
       */
-    BRAYNS_API void removeModel(const size_t id);
+    BRAYNS_API bool removeModel(const size_t id);
 
     BRAYNS_API ModelDescriptorPtr getModel(const size_t id) const;
 

--- a/brayns/io/simulation/CADiffusionSimulationHandler.cpp
+++ b/brayns/io/simulation/CADiffusionSimulationHandler.cpp
@@ -113,5 +113,6 @@ void CADiffusionSimulationHandler::setFrame(Scene& scene, const size_t frame)
         model->addSphere(CALCIUM_MATERIAL_ID, {position, CALCIUM_RADIUS});
     _modelID = scene.addModel(
         std::make_shared<ModelDescriptor>(std::move(model), modelName));
+    scene.markModified();
 }
 }

--- a/plugins/RocketsPlugin/RocketsPlugin.cpp
+++ b/plugins/RocketsPlugin/RocketsPlugin.cpp
@@ -1186,6 +1186,7 @@ public:
         _handleRPC<size_ts, bool>(desc, [engine = _engine](const size_ts& ids) {
             for (const auto id : ids)
                 engine->getScene().removeModel(id);
+            engine->getScene().markModified();
             engine->triggerRender();
             return true;
         });

--- a/plugins/RocketsPlugin/RocketsPlugin.cpp
+++ b/plugins/RocketsPlugin/RocketsPlugin.cpp
@@ -349,8 +349,7 @@ public:
 #endif
     }
 
-    void _rebroadcast(const std::string& endpoint,
-                      const std::string& message,
+    void _rebroadcast(const std::string& endpoint, const std::string& message,
                       const std::set<uintptr_t>& filter)
     {
         _delayedNotify([&, message, filter] {
@@ -1274,8 +1273,8 @@ public:
                 model->setProperties(props);
                 _engine->triggerRender();
 
-                this->_rebroadcast(METHOD_SET_MODEL_PROPERTIES,
-                                   request.message, {request.clientID});
+                this->_rebroadcast(METHOD_SET_MODEL_PROPERTIES, request.message,
+                                   {request.clientID});
 
                 return Response{to_json(true)};
             }

--- a/tests/addModel.cpp
+++ b/tests/addModel.cpp
@@ -115,6 +115,7 @@ BOOST_AUTO_TEST_CASE(xyz_obj)
     auto newNbModels = getScene().getNumModels();
     BOOST_CHECK_EQUAL(initialNbModels + 2, newNbModels);
     getScene().removeModel(newNbModels - 1);
+    getScene().markModified();
     newNbModels = getScene().getNumModels();
     BOOST_CHECK_EQUAL(initialNbModels + 1, newNbModels);
 }


### PR DESCRIPTION
This avoids spamming update callbacks if adding or removing many models at the same time.