### PR TITLE
Support subsampling again after OSPRay 1.7 upgrade

### DIFF
--- a/apps/ui/BaseWindow.h
+++ b/apps/ui/BaseWindow.h
@@ -96,14 +96,6 @@ public:
     /*! clear the frame buffer color and depth bits */
     void clearPixels();
 
-    /*! draw uint pixels into the GLUT window (assumes window and buffer
-     * dimensions are equal) */
-    void drawPixels(const int* framebuffer);
-
-    /*! draw float4 pixels into the GLUT window (assumes window and buffer
-     * dimensions are equal) */
-    void drawPixels(const Vector3f* framebuffer);
-
     virtual void keypress(char key, const Vector2f& where);
     virtual void specialkey(int key, const Vector2f& where);
 
@@ -149,8 +141,10 @@ protected:
     bool _fullScreen;
     Vector2ui _windowPosition;
 
+    GLuint _fbTexture{0};
+
 private:
-    void _exitApplication();
+    void _onExit();
     void _toggleFrameBuffer();
 
     // ------------------------------------------------------------------

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -177,9 +177,9 @@ struct Brayns::Impl : public PluginAPI
 
         _engine->getStatistics().setFPS(_lastFPS);
 
-        _engine->postRender();
-
         _pluginManager.postRender();
+
+        _engine->postRender();
 
         _engine->getFrameBuffer().resetModified();
         _engine->getStatistics().resetModified();
@@ -200,7 +200,7 @@ struct Brayns::Impl : public PluginAPI
         FrameBuffer& frameBuffer = _engine->getFrameBuffer();
         frameBuffer.map();
         const Vector2i& frameSize = frameBuffer.getSize();
-        uint8_t* colorBuffer = frameBuffer.getColorBuffer();
+        const auto colorBuffer = frameBuffer.getColorBuffer();
         if (colorBuffer)
         {
             const size_t size =
@@ -209,7 +209,7 @@ struct Brayns::Impl : public PluginAPI
             renderOutput.colorBufferFormat = frameBuffer.getFrameBufferFormat();
         }
 
-        float* depthBuffer = frameBuffer.getDepthBuffer();
+        const auto depthBuffer = frameBuffer.getDepthBuffer();
         if (depthBuffer)
         {
             const size_t size = frameSize.x() * frameSize.y();
@@ -460,8 +460,9 @@ private:
             'g', "Enable/Disable animation playback",
             std::bind(&Brayns::Impl::_toggleAnimationPlayback, this));
         _keyboardHandler.registerKeyboardShortcut(
-            'x', "Set animation frame to " +
-                     std::to_string(DEFAULT_TEST_ANIMATION_FRAME),
+            'x',
+            "Set animation frame to " +
+                std::to_string(DEFAULT_TEST_ANIMATION_FRAME),
             std::bind(&Brayns::Impl::_defaultAnimationFrame, this));
         _keyboardHandler.registerKeyboardShortcut(
             '|', "Create cache file ",

--- a/brayns/common/engine/Engine.cpp
+++ b/brayns/common/engine/Engine.cpp
@@ -48,6 +48,11 @@ void Engine::reshape(const Vector2ui& frameSize)
 
 void Engine::commit()
 {
+    const auto spp =
+        _parametersManager.getRenderingParameters().getSamplesPerPixel();
+    const size_t factor = spp >= 0 ? 1 : std::pow(2, std::abs(spp));
+    _frameBuffer->setSubsampling(factor);
+
     _renderer->commit();
 }
 
@@ -59,6 +64,7 @@ void Engine::render()
 void Engine::postRender()
 {
     _writeFrameToFile();
+    _frameBuffer->incrementAccumFrames();
 }
 
 Renderer& Engine::getRenderer()

--- a/brayns/common/renderer/FrameBuffer.cpp
+++ b/brayns/common/renderer/FrameBuffer.cpp
@@ -31,7 +31,7 @@ FrameBuffer::FrameBuffer(const Vector2ui& frameSize,
 {
 }
 
-size_t FrameBuffer::getColorDepth()
+size_t FrameBuffer::getColorDepth() const
 {
     switch (_frameBufferFormat)
     {

--- a/brayns/common/renderer/FrameBuffer.h
+++ b/brayns/common/renderer/FrameBuffer.h
@@ -38,13 +38,13 @@ public:
     virtual void map() = 0;
     virtual void unmap() = 0;
 
-    virtual uint8_t* getColorBuffer() = 0;
-    virtual size_t getColorDepth();
-    virtual float* getDepthBuffer() = 0;
+    virtual const uint8_t* getColorBuffer() const = 0;
+    virtual size_t getColorDepth() const;
+    virtual const float* getDepthBuffer() const = 0;
 
     virtual void resize(const Vector2ui& frameSize) = 0;
 
-    Vector2ui getSize() const { return _frameSize; }
+    virtual Vector2ui getSize() const { return _frameSize; }
     virtual void setAccumulation(const bool accumulation)
     {
         _accumulation = accumulation;
@@ -57,6 +57,9 @@ public:
 
     void incrementAccumFrames() { ++_accumFrames; }
     size_t numAccumFrames() const { return _accumFrames; }
+
+    virtual void setSubsampling(const size_t) {}
+
 protected:
     Vector2ui _frameSize;
     FrameBufferFormat _frameBufferFormat;

--- a/brayns/common/utils/ImageUtils.cpp
+++ b/brayns/common/utils/ImageUtils.cpp
@@ -69,8 +69,9 @@ ImagePtr getImageFromFrameBuffer(FrameBuffer& frameBuffer)
     const auto& size = frameBuffer.getSize();
 
     ImagePtr image(FreeImage_ConvertFromRawBits(
-        colorBuffer, size.x(), size.y(), frameBuffer.getColorDepth() * size.x(),
-        8 * frameBuffer.getColorDepth(), 0xFF0000, 0x00FF00, 0x0000FF, false));
+        const_cast<uint8_t*>(colorBuffer), size.x(), size.y(),
+        frameBuffer.getColorDepth() * size.x(), 8 * frameBuffer.getColorDepth(),
+        0xFF0000, 0x00FF00, 0x0000FF, false));
 
     frameBuffer.unmap();
 

--- a/engines/ospray/OSPRayEngine.cpp
+++ b/engines/ospray/OSPRayEngine.cpp
@@ -198,11 +198,27 @@ void OSPRayEngine::preRender()
 
 Vector2ui OSPRayEngine::getSupportedFrameSize(const Vector2ui& size) const
 {
-    // In case of 3D stereo vision, make sure the width is even
-    if (_camera->isSideBySideStereo() && size.x() % 2 != 0)
-        return {size.x() - 1, size.y()};
+    const auto isSideBySideStereo = _camera->isSideBySideStereo();
 
-    return size;
+    if (!haveDeflectPixelOp())
+    {
+        Vector2f result = size;
+        if (isSideBySideStereo && size.x() % 2 != 0)
+        {
+            // In case of 3D stereo vision, make sure the width is even
+            result.x() = size.x() - 1;
+        }
+        return result;
+    }
+
+    Vector2f result = size;
+    if (isSideBySideStereo)
+    {
+        if (size.x() % (TILE_SIZE * 2) != 0)
+            result.x() = size.x() - size.x() % (TILE_SIZE * 2);
+    }
+
+    return result;
 }
 
 Vector2ui OSPRayEngine::getMinimumFrameSize() const

--- a/engines/ospray/OSPRayEngine.cpp
+++ b/engines/ospray/OSPRayEngine.cpp
@@ -198,35 +198,11 @@ void OSPRayEngine::preRender()
 
 Vector2ui OSPRayEngine::getSupportedFrameSize(const Vector2ui& size) const
 {
-    const auto isSideBySideStereo = _camera->isSideBySideStereo();
+    // In case of 3D stereo vision, make sure the width is even
+    if (_camera->isSideBySideStereo() && size.x() % 2 != 0)
+        return {size.x() - 1, size.y()};
 
-    if (!haveDeflectPixelOp())
-    {
-        Vector2f result = size;
-        if (isSideBySideStereo && size.x() % 2 != 0)
-        {
-            // In case of 3D stereo vision, make sure the width is even
-            result.x() = size.x() - 1;
-        }
-        return result;
-    }
-
-    Vector2f result = size;
-    if (isSideBySideStereo)
-    {
-        if (size.x() % (TILE_SIZE * 2) != 0)
-            result.x() = size.x() - size.x() % (TILE_SIZE * 2);
-    }
-    else
-    {
-        if (size.x() % TILE_SIZE != 0)
-            result.x() = size.x() - size.x() % TILE_SIZE;
-    }
-
-    if (size.y() % TILE_SIZE != 0)
-        result.y() = size.y() - size.y() % TILE_SIZE;
-
-    return result;
+    return size;
 }
 
 Vector2ui OSPRayEngine::getMinimumFrameSize() const

--- a/engines/ospray/OSPRayRenderer.cpp
+++ b/engines/ospray/OSPRayRenderer.cpp
@@ -52,7 +52,6 @@ void OSPRayRenderer::render(FrameBufferPtr frameBuffer)
     _variance = ospRenderFrame(osprayFrameBuffer->impl(), _renderer,
                                OSP_FB_COLOR | OSP_FB_DEPTH | OSP_FB_ACCUM);
 
-    osprayFrameBuffer->incrementAccumFrames();
     osprayFrameBuffer->markModified();
 }
 
@@ -103,7 +102,7 @@ void OSPRayRenderer::commit()
     const auto& color = rp.getBackgroundColor();
     ospSet3f(_renderer, "bgColor", color.x(), color.y(), color.z());
     ospSet1f(_renderer, "varianceThreshold", rp.getVarianceThreshold());
-    ospSet1i(_renderer, "spp", rp.getSamplesPerPixel());
+    ospSet1i(_renderer, "spp", std::max(1, rp.getSamplesPerPixel()));
 
     if (auto material = std::static_pointer_cast<OSPRayMaterial>(
             scene->getBackgroundMaterial()))

--- a/ospray_modules/CMakeLists.txt
+++ b/ospray_modules/CMakeLists.txt
@@ -5,6 +5,15 @@
 #
 # This file is part of Brayns <https://github.com/BlueBrain/Brayns>
 
+# Deflect PixelOp module
+option(BRAYNS_DEFLECT_PIXELOP_ENABLED "Activate Deflect PixelOp module" OFF)
+if(BRAYNS_DEFLECT_PIXELOP_ENABLED)
+  add_subdirectory(deflect)
+  if(TARGET ospray_module_deflect)
+    add_dependencies(braynsOSPRayEngine ospray_module_deflect)
+  endif()
+endif()
+
 # Optix module
 option(BRAYNS_OPTIX_ENABLED "Activate OptiX module" OFF)
 if(BRAYNS_OPTIX_ENABLED)

--- a/ospray_modules/deflect/CMakeLists.txt
+++ b/ospray_modules/deflect/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2017, EPFL/Blue Brain Project
+# All rights reserved. Do not distribute without permission.
+# Responsible Author: Daniel Nachbaur <daniel.nachbaur@epfl.ch>
+#
+# This file is part of https://github.com/BlueBrain/ospray-modules
+
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(ospray_module_deflect VERSION 1.0.0)
+set(ospray_module_deflect_VERSION_ABI 1)
+
+include(Common)
+
+common_find_package(Deflect REQUIRED)
+common_find_package(OpenMP)
+common_find_package(ospray REQUIRED SYSTEM)
+common_find_package_post()
+
+set(OSPRAY_MODULE_DEFLECT_OMIT_LIBRARY_HEADER ON)
+set(OSPRAY_MODULE_DEFLECT_OMIT_VERSION_HEADERS ON)
+set(OSPRAY_MODULE_DEFLECT_HEADERS DeflectPixelOp.h)
+set(OSPRAY_MODULE_DEFLECT_SOURCES DeflectPixelOp.cpp)
+set(OSPRAY_MODULE_DEFLECT_LINK_LIBRARIES PRIVATE Deflect)
+common_library(ospray_module_deflect)

--- a/ospray_modules/deflect/DeflectPixelOp.cpp
+++ b/ospray_modules/deflect/DeflectPixelOp.cpp
@@ -1,0 +1,277 @@
+/* Copyright (c) 2017-2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Daniel Nachbaur <daniel.nachbaur@epfl.ch>
+ *
+ * This file is part of https://github.com/BlueBrain/Brayns
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "DeflectPixelOp.h"
+
+#include <ospray/SDK/fb/FrameBuffer.h>
+
+namespace
+{
+template <typename T>
+std::future<T> make_ready_future(const T value)
+{
+    std::promise<T> promise;
+    promise.set_value(value);
+    return promise.get_future();
+}
+
+#pragma omp declare simd
+inline unsigned char clampCvt(float f)
+{
+    if (f < 0.f)
+        f = 0.f;
+    if (f > 1.f)
+        f = 1.f;
+    return f * 255.f;
+}
+
+const size_t ALIGNMENT = 64;
+}
+
+namespace bbp
+{
+DeflectPixelOp::Instance::Instance(ospray::FrameBuffer* fb_,
+                                   DeflectPixelOp& parent)
+    : _parent(parent)
+{
+    fb = fb_;
+}
+
+DeflectPixelOp::Instance::~Instance() = default;
+
+void DeflectPixelOp::Instance::beginFrame()
+{
+    if (!_parent._deflectStream)
+        return;
+    const size_t numTiles = fb->getTotalTiles();
+    if (_pixels.size() < numTiles)
+    {
+        _pixels.resize(numTiles);
+
+        for (auto& i : _pixels)
+        {
+            if (i)
+                continue;
+
+            i.reset((unsigned char*)_mm_malloc(TILE_SIZE * TILE_SIZE * 4,
+                                               ALIGNMENT));
+            memset(i.get(), 255, TILE_SIZE * TILE_SIZE * 4);
+        }
+    }
+}
+
+void DeflectPixelOp::Instance::endFrame()
+{
+    if (!_parent._deflectStream)
+        return;
+
+    auto sharedFuture = _parent._deflectStream->finishFrame().share();
+    for (auto& i : _parent._finishFutures)
+        i.second = sharedFuture;
+}
+
+void DeflectPixelOp::Instance::postAccum(ospray::Tile& tile)
+{
+    if (!_parent._deflectStream)
+        return;
+
+    unsigned int x = tile.region.lower.x;
+    bool isRightEye = false;
+    if (_parent._settings.stereo)
+    {
+        unsigned int widthHalf = fb->getNumPixels().x / 2;
+        isRightEye = x >= widthHalf;
+        if (isRightEye)
+            x -= widthHalf;
+    }
+
+    const auto& fbSize = fb->getNumPixels();
+    ospray::vec2i tileSize{TILE_SIZE, TILE_SIZE};
+
+    if (tile.region.lower.x + TILE_SIZE >= fbSize.x)
+        tileSize.x = fbSize.x % TILE_SIZE;
+    if (tile.region.lower.y + TILE_SIZE >= fbSize.y)
+        tileSize.y = fbSize.y % TILE_SIZE;
+
+    deflect::ImageWrapper image(_copyPixels(tile, tileSize), tileSize.x,
+                                tileSize.y, deflect::RGBA, x,
+                                tile.region.lower.y);
+    image.compressionPolicy = _parent._settings.compression
+                                  ? deflect::COMPRESSION_ON
+                                  : deflect::COMPRESSION_OFF;
+    image.compressionQuality = _parent._settings.quality;
+    image.subsampling = deflect::ChromaSubsampling::YUV420;
+    image.rowOrder = deflect::RowOrder::bottom_up;
+    if (_parent._settings.stereo)
+        image.view =
+            isRightEye ? deflect::View::right_eye : deflect::View::left_eye;
+
+    try
+    {
+        auto i = _parent._finishFutures.find(pthread_self());
+        if (i == _parent._finishFutures.end())
+        {
+            // only for the first frame
+            std::lock_guard<std::mutex> _lock(_parent._mutex);
+            _parent._finishFutures.insert(
+                {pthread_self(), make_ready_future(true)});
+        }
+        else
+            i->second.wait(); // complete previous frame
+
+        _parent._deflectStream->send(image).get();
+    }
+    catch (const std::exception& exc)
+    {
+        std::cerr << "Encountered error during sendImage: " << exc.what()
+                  << std::endl;
+    }
+}
+
+unsigned char* DeflectPixelOp::Instance::_copyPixels(
+    ospray::Tile& tile, const ospray::vec2i& tileSize)
+{
+    const size_t tileID =
+        tile.region.lower.y / TILE_SIZE * fb->getNumTiles().x +
+        tile.region.lower.x / TILE_SIZE;
+
+#ifdef __GNUC__
+    unsigned char* __restrict__ pixels =
+        (unsigned char*)__builtin_assume_aligned(_pixels[tileID].get(),
+                                                 ALIGNMENT);
+#else
+    unsigned char* __restrict__ pixels = _pixels[tileID].get();
+#endif
+    float* __restrict__ red = tile.r;
+    float* __restrict__ green = tile.g;
+    float* __restrict__ blue = tile.b;
+
+    if (tileSize.x < TILE_SIZE)
+    {
+        int index = 0;
+        for (int i = 0; i < tileSize.y; ++i)
+        {
+            for (int j = 0; j < tileSize.x; ++j)
+            {
+                pixels[index + 0] = clampCvt(red[i * TILE_SIZE + j]);
+                pixels[index + 1] = clampCvt(green[i * TILE_SIZE + j]);
+                pixels[index + 2] = clampCvt(blue[i * TILE_SIZE + j]);
+                index += 4;
+            }
+        }
+        return pixels;
+    }
+
+// clang-format off
+    // AVX vectorization with icc 17 reports (create with -qopt-report=5)
+    //LOOP BEGIN at ../plugins/engines/ospray/modules/deflect/DeflectPixelOp.cpp(130,16)
+    //   remark #15388: vectorization support: reference red[i] has aligned access
+    //   remark #15388: vectorization support: reference green[i] has aligned access
+    //   remark #15388: vectorization support: reference blue[i] has aligned access
+    //   remark #15329: vectorization support: non-unit strided store was emulated for the variable <U137_V[i*4]>, stride is 4
+    //   remark #15329: vectorization support: non-unit strided store was emulated for the variable <U137_V[i*4+1]>, stride is 4
+    //   remark #15329: vectorization support: non-unit strided store was emulated for the variable <U137_V[i*4+2]>, stride is 4
+    //   remark #15305: vectorization support: vector length 32
+    //   remark #15301: OpenMP SIMD LOOP WAS VECTORIZED
+    //   remark #15448: unmasked aligned unit stride loads: 3
+    //   remark #15453: unmasked strided stores: 3
+    //   remark #15475: --- begin vector cost summary ---
+    //   remark #15476: scalar cost: 56
+    //   remark #15477: vector cost: 9.460
+    //   remark #15478: estimated potential speedup: 5.910
+    //   remark #15487: type converts: 3
+    //   remark #15488: --- end vector cost summary ---
+    //   remark #25015: Estimate of max trip count of loop=128
+    //LOOP END
+// clang-format on
+#ifdef __INTEL_COMPILER
+#pragma vector aligned
+#endif
+#pragma omp simd
+    for (int i = 0; i < TILE_SIZE * TILE_SIZE; ++i)
+    {
+        pixels[i * 4 + 0] = clampCvt(red[i]);
+        pixels[i * 4 + 1] = clampCvt(green[i]);
+        pixels[i * 4 + 2] = clampCvt(blue[i]);
+    }
+    return pixels;
+}
+
+void DeflectPixelOp::commit()
+{
+    const std::string hostname = getParamString("hostname", "");
+    const std::string id = getParamString("id", "");
+    const bool changed = _settings.id != id || _settings.hostname != hostname;
+
+    _settings.id = id;
+    _settings.hostname = hostname;
+    _settings.port = getParam1i("port", deflect::Stream::defaultPortNumber);
+    _settings.compression = getParam1i("compression", 1);
+    _settings.stereo = getParam1i("stereo", 0);
+    _settings.quality = getParam1i("quality", 80);
+    _settings.streamEnabled = getParam1i("enabled", 1);
+
+    if (changed || (_deflectStream && _deflectStream->isConnected() &&
+                    !_settings.streamEnabled))
+    {
+        finish();
+        _deflectStream.reset();
+    }
+
+    if (!_deflectStream && _settings.streamEnabled)
+    {
+        try
+        {
+            _deflectStream.reset(new deflect::Stream(_settings.id,
+                                                     _settings.hostname,
+                                                     _settings.port));
+        }
+        catch (const std::runtime_error& ex)
+        {
+            std::cerr << "Deflect failed to initialize. " << ex.what()
+                      << std::endl;
+            _settings.streamEnabled = false;
+        }
+    }
+}
+
+ospray::PixelOp::Instance* DeflectPixelOp::createInstance(
+    ospray::FrameBuffer* fb, PixelOp::Instance* /*prev*/)
+{
+    return new Instance(fb, *this);
+}
+
+void DeflectPixelOp::finish()
+{
+    for (auto& i : _finishFutures)
+        i.second.wait();
+    _finishFutures.clear();
+}
+
+} // namespace bbp
+
+namespace ospray
+{
+extern "C" void ospray_init_module_deflect()
+{
+    std::cout << "#deflect: initializing ospray deflect plugin" << std::endl;
+}
+OSP_REGISTER_PIXEL_OP(bbp::DeflectPixelOp, DeflectPixelOp);
+}

--- a/ospray_modules/deflect/DeflectPixelOp.h
+++ b/ospray_modules/deflect/DeflectPixelOp.h
@@ -1,0 +1,100 @@
+/* Copyright (c) 2017-2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Daniel Nachbaur <daniel.nachbaur@epfl.ch>
+ *
+ * This file is part of https://github.com/BlueBrain/Brayns
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <deflect/Stream.h>
+#include <map>
+#include <ospray/SDK/fb/PixelOp.h>
+
+namespace bbp
+{
+/**
+ * Implements an ospray pixel op that streams each tile to a Deflect server
+ * instance. The tiles are compressed directly on the tile thread and then
+ * enqueued for sending.
+ *
+ * The ospray module to load is called "deflect", and the pixel op name for
+ * creating it is "DeflectPixelOp".
+ */
+class DeflectPixelOp : public ospray::PixelOp
+{
+public:
+    struct Settings
+    {
+        std::string id;
+        std::string hostname;
+        uint16_t port{deflect::Stream::defaultPortNumber};
+        bool compression{true};
+        bool stereo{false}; // side-by-side
+        bool streamEnabled{true};
+        unsigned int quality{80};
+    };
+
+    struct Instance : public ospray::PixelOp::Instance
+    {
+        Instance(ospray::FrameBuffer* fb_, DeflectPixelOp& parent);
+        ~Instance();
+
+        void beginFrame() final;
+        void endFrame() final;
+        void postAccum(ospray::Tile& tile) final;
+        std::string toString() const final { return "DeflectPixelOp"; }
+        struct PixelsDeleter
+        {
+            void operator()(unsigned char* pixels) { _mm_free(pixels); }
+        };
+        using Pixels = std::unique_ptr<unsigned char, PixelsDeleter>;
+
+    private:
+        DeflectPixelOp& _parent;
+        std::vector<Pixels> _pixels;
+
+        unsigned char* _copyPixels(ospray::Tile& tile,
+                                   const ospray::vec2i& tileSize);
+    };
+
+    /**
+     * Updates the underlying deflect stream with the following parameters:
+     * - "enabled" (param1i): 1 to enable streaming, 0 to disable streaming,
+     *                        1 default
+     * - "compression" (param1i): 1 to enable compression, 0 to send raw,
+     *                            uncompressed pixels, 1 default
+     * - "quality" (param1i): 1 (worst, smallest) - 100 (best, biggest) for JPEG
+     *                        quality, 80 default
+     * - "stereo" (param1i): 0 (off), 1 (on) to indicate side-by-side stereo to
+     *                       to stream left half of tiles as
+     *                       deflect::View::left_eye and right eye accordingly.
+     */
+    void commit() final;
+
+    ospray::PixelOp::Instance* createInstance(ospray::FrameBuffer* fb,
+                                              PixelOp::Instance* prev) final;
+
+    /** @internal finish pendings sends before closing the stream. */
+    void finish();
+
+private:
+    std::unique_ptr<deflect::Stream> _deflectStream;
+    std::map<pthread_t, std::shared_future<bool>> _finishFutures;
+    std::mutex _mutex;
+    Settings _settings;
+};
+}

--- a/plugins/Deflect/DeflectPlugin.cpp
+++ b/plugins/Deflect/DeflectPlugin.cpp
@@ -324,7 +324,7 @@ private:
         const auto& size = frameBuffer.getSize();
         const size_t bufferSize =
             size.x() * size.y() * frameBuffer.getColorDepth();
-        void* data = frameBuffer.getColorBuffer();
+        const auto data = frameBuffer.getColorBuffer();
 
         _lastImage.data.resize(bufferSize);
         memcpy(_lastImage.data.data(), data, bufferSize);

--- a/plugins/Rockets/ImageGenerator.cpp
+++ b/plugins/Rockets/ImageGenerator.cpp
@@ -58,7 +58,7 @@ ImageGenerator::ImageJPEG ImageGenerator::createJPEG(
 {
 #ifdef BRAYNS_USE_LIBJPEGTURBO
     frameBuffer.map();
-    auto colorBuffer = frameBuffer.getColorBuffer();
+    const auto colorBuffer = frameBuffer.getColorBuffer();
     if (!colorBuffer)
     {
         frameBuffer.unmap();

--- a/plugins/Rockets/SnapshotTask.h
+++ b/plugins/Rockets/SnapshotTask.h
@@ -122,6 +122,7 @@ public:
             progress(msg.str(), 1.f / _frameBuffer->numAccumFrames(),
                      float(_frameBuffer->numAccumFrames()) /
                          _params.samplesPerPixel);
+            _frameBuffer->incrementAccumFrames();
         }
 
         return _imageGenerator.createImage(*_frameBuffer, _params.format,

--- a/python/brayns/base.py
+++ b/python/brayns/base.py
@@ -148,6 +148,7 @@ class BaseClient:
                 from rx import Observer
 
                 rockets_client = self.rockets_client
+                brayns = self
 
                 class ImageStreamObserver(Observer):
                     """Update a Image widget with the JPEG stream from Brayns."""
@@ -157,6 +158,9 @@ class BaseClient:
 
                         def _show_image(value):
                             self.image.value = base64decode(value['data'])
+                            viewport = brayns.application_parameters.viewport
+                            self.image.width = viewport[0]
+                            self.image.height = viewport[1]
                             display(self.image)
 
                         if isinstance(rockets_client, rockets.AsyncClient):
@@ -166,6 +170,9 @@ class BaseClient:
                             _show_image(rockets_client.request('image-jpeg'))
 
                     def on_next(self, value):
+                        viewport = brayns.application_parameters.viewport
+                        self.image.width = viewport[0]
+                        self.image.height = viewport[1]
                         self.image.value = value
 
                     def on_completed(self):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(NOT BRAYNS_OSPRAY_ENABLED)
     testImages.cpp
     webAPI.cpp
     shadows.cpp
+    subsampling.cpp
     transferFunction.cpp
   )
 endif()

--- a/tests/subsampling.cpp
+++ b/tests/subsampling.cpp
@@ -1,0 +1,65 @@
+/* Copyright (c) 2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Daniel.Nachbaur@epfl.ch
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <brayns/Brayns.h>
+
+#include <brayns/common/engine/Engine.h>
+#include <brayns/common/renderer/FrameBuffer.h>
+
+#define BOOST_TEST_MODULE braynsSubsampling
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(subsampling_buffer_size)
+{
+    auto& testSuite = boost::unit_test::framework::master_test_suite();
+    const char* app = testSuite.argv[0];
+    const char* argv[] = {app,   "--window-size",       "400",
+                          "200", "--samples-per-pixel", "-2",
+                          "demo"};
+    const int argc = sizeof(argv) / sizeof(char*);
+    brayns::Brayns brayns(argc, argv);
+
+    brayns.commitAndRender();
+    BOOST_CHECK_EQUAL(brayns.getEngine().getFrameBuffer().getSize(),
+                      brayns::Vector2ui(100, 50));
+
+    brayns.commitAndRender();
+    BOOST_CHECK_EQUAL(brayns.getEngine().getFrameBuffer().getSize(),
+                      brayns::Vector2ui(400, 200));
+}
+
+BOOST_AUTO_TEST_CASE(no_subsampling_needed)
+{
+    auto& testSuite = boost::unit_test::framework::master_test_suite();
+    const char* app = testSuite.argv[0];
+    const char* argv[] = {app,   "--window-size",       "400",
+                          "200", "--samples-per-pixel", "2",
+                          "demo"};
+    const int argc = sizeof(argv) / sizeof(char*);
+    brayns::Brayns brayns(argc, argv);
+
+    brayns.commitAndRender();
+    BOOST_CHECK_EQUAL(brayns.getEngine().getFrameBuffer().getSize(),
+                      brayns::Vector2ui(400, 200));
+
+    brayns.commitAndRender();
+    BOOST_CHECK_EQUAL(brayns.getEngine().getFrameBuffer().getSize(),
+                      brayns::Vector2ui(400, 200));
+}


### PR DESCRIPTION
This implies that the subsampled framebuffer which is used during interaction (and a
negative samples-per-pixel value), is now smaller than the window/viewport size.

Hence, clients are supposed to scale the image/framebuffer. This is done for the
braynsViewer using a texture.