### PR TITLE
Brayns initialization modified

### DIFF
--- a/apps/BraynsViewer/BraynsViewer.cpp
+++ b/apps/BraynsViewer/BraynsViewer.cpp
@@ -32,7 +32,6 @@ namespace brayns
 BraynsViewer::BraynsViewer(Brayns& brayns)
     : BaseWindow(brayns)
 {
-    brayns.loadPlugins();
 }
 
 void BraynsViewer::display()

--- a/brayns/Brayns.h
+++ b/brayns/Brayns.h
@@ -33,34 +33,37 @@ namespace brayns
     underlying rendering engines, making it possible to use the best rendering
     engine depending on the case.
 
-    The scene is initialized according to parameters provided to the Brayns
-    constructor. Those parameters are related to the application itself, the
-    geometry and the renderer. During the initialization process, Brayns creates
-    the scene using loaders located in the braynsPlugins library.
+    Brayns uses plugins for extended function. There are a few built-in plugins
+    and additional plugins can be dynamically loaded.
 
     The underlying rendering engine (OSPRay, Optix, FireRays, etc) is specified
     in the rendering parameters and is invoked by the render method for
     generating the frames.
 
     Underlying rendering engines support CPU, GPU and heterogeneous
-   architectures
+    architectures
 
     This object exposes the basic API for Brayns
 */
 class Brayns
 {
 public:
+    /** Brayns instance initialization.
+     *
+     * Initialization involves command line parsing, engine creation, plugin
+     * loading and initialization, data loading, scene creation and setup of
+     * keyboard mouse interactions.
+     *
+     * In a setup using event loops, the event loop must be set up correctly
+     * before calling this constructor to ensure that plugins can install their
+     * event callbacks successfully.
+     *
+     * Command line parameters provide options about the application itself,
+     * the geometry and the renderer. Brayns creates the scene using built-in
+     * and plug-in provided loaders.
+     */
     BRAYNS_API Brayns(int argc, const char** argv);
     BRAYNS_API ~Brayns();
-
-    /**
-     * Creates built-in plugins and loads specified dynamic plugins. Shall be
-     * invoked before starting any rendering.
-     *
-     * In a setup using event loops, one wants to postpone this call until the
-     * event loop is setup'd correctly to use it from within a plugin.
-     */
-    BRAYNS_API void loadPlugins();
 
     /** @name Simple execution API  */
     //@{

--- a/brayns/common/utils/DynamicLib.cpp
+++ b/brayns/common/utils/DynamicLib.cpp
@@ -1,3 +1,23 @@
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Juan Hernando <juan.hernando@epfl.ch>
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN

--- a/brayns/common/utils/DynamicLib.h
+++ b/brayns/common/utils/DynamicLib.h
@@ -1,18 +1,22 @@
-// ======================================================================== //
-// Copyright 2009-2018 Intel Corporation                                    //
-//                                                                          //
-// Licensed under the Apache License, Version 2.0 (the "License");          //
-// you may not use this file except in compliance with the License.         //
-// You may obtain a copy of the License at                                  //
-//                                                                          //
-//     http://www.apache.org/licenses/LICENSE-2.0                           //
-//                                                                          //
-// Unless required by applicable law or agreed to in writing, software      //
-// distributed under the License is distributed on an "AS IS" BASIS,        //
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. //
-// See the License for the specific language governing permissions and      //
-// limitations under the License.                                           //
-// ======================================================================== //
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Juan Hernando <juan.hernando@epfl.ch>
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 #pragma once
 

--- a/tests/ClientServer.h
+++ b/tests/ClientServer.h
@@ -101,7 +101,6 @@ public:
             argv.push_back(arg);
         const int argc = argv.size();
         _brayns.reset(new brayns::Brayns(argc, argv.data()));
-        _brayns->loadPlugins();
         _brayns->getParametersManager()
             .getApplicationParameters()
             .setImageStreamFPS(0);


### PR DESCRIPTION
Plugin loading now happens in the constructor, as it's needed to register
loaders from plugins before loading occurs (this will be the case of the
upcoming CircuitViewer plugin).

In braynsService, the event loop setup now must be done before creating
the Brayns instance.