### PR TITLE
Plugin loading and initialization split in two phases.

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -77,7 +77,7 @@ namespace brayns
 struct Brayns::Impl : public PluginAPI
 {
     Impl(int argc, const char** argv)
-        : _pluginManager{this, argc, argv}
+        : _pluginManager{argc, argv}
         , _engineFactory{argc, argv, _parametersManager}
     {
         BRAYNS_INFO << "Parsing command line options" << std::endl;

--- a/brayns/CMakeLists.txt
+++ b/brayns/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BRAYNS_HEADERS EngineFactory.h)
 set(BRAYNS_SOURCES
   Brayns.cpp
   EngineFactory.cpp
+  PluginManager.cpp
 )
 
 set(BRAYNS_LINK_LIBRARIES

--- a/brayns/PluginManager.cpp
+++ b/brayns/PluginManager.cpp
@@ -1,0 +1,144 @@
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Juan Hernando <cyrille.favreau@epfl.ch>
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "PluginManager.h"
+
+#include <brayns/common/log.h>
+#include <brayns/parameters/ParametersManager.h>
+
+#include <brayns/pluginapi/ExtensionPlugin.h>
+#include <brayns/pluginapi/PluginAPI.h>
+#ifdef BRAYNS_USE_NETWORKING
+#include <plugins/Rockets/RocketsPlugin.h>
+#endif
+#ifdef BRAYNS_USE_DEFLECT
+#include <plugins/Deflect/DeflectPlugin.h>
+#endif
+
+#include <boost/algorithm/string.hpp>
+
+namespace brayns
+{
+typedef ExtensionPlugin* (*CreateFuncType)(PluginAPI*, int, const char**);
+
+PluginManager::PluginManager(PluginAPI* api, int argc, const char** argv)
+{
+    for (int i = 0; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--plugin") != 0)
+            continue;
+        if (++i == argc || argv[i][0] == '\0' || argv[i][0] == '-')
+        {
+            // Do not print anything here, errors will be reported later
+            // during option parsing
+            continue;
+        }
+
+        std::string str(argv[i]);
+        boost::trim(str);
+        std::vector<std::string> words;
+        boost::split(words, str, boost::is_any_of(" "),
+                     boost::token_compress_on);
+
+        const char* name = words.front().c_str();
+        std::vector<const char*> args;
+        for (const auto& w : words)
+            args.push_back(w.c_str());
+
+        _loadPlugin(api, name, args.size(), args.data());
+    }
+}
+
+void PluginManager::initPlugins(PluginAPI* api)
+{
+    // Rockets and Deflect plugins cannot be initialized until we have
+    // the command line parameters
+    auto& parameters = api->getParametersManager();
+    auto& appParameters = parameters.getApplicationParameters();
+    auto& streamParameters = parameters.getStreamParameters();
+
+    const bool haveHttpServerURI = !appParameters.getHttpServerURI().empty();
+
+    const bool haveDeflectHost =
+        getenv("DEFLECT_HOST") || !streamParameters.getHostname().empty();
+    if (haveDeflectHost)
+#ifdef BRAYNS_USE_DEFLECT
+        _extensions.push_back(std::make_shared<DeflectPlugin>());
+#else
+        throw std::runtime_error(
+            "BRAYNS_DEFLECT_ENABLED was not set, but Deflect host was "
+            "specified");
+#endif
+
+    if (haveHttpServerURI)
+#ifdef BRAYNS_USE_NETWORKING
+        // Since the Rockets plugin provides the ActionInterface, it must be
+        // initialized before anything else
+        _extensions.insert(_extensions.begin(),
+                           std::make_shared<RocketsPlugin>());
+#else
+        throw std::runtime_error(
+            "BRAYNS_NETWORKING_ENABLED was not set, but HTTP server URI "
+            "was specified");
+#endif
+
+    for (const auto& extension : _extensions)
+        extension->init(api);
+}
+
+void PluginManager::preRender()
+{
+    for (const auto& extension : _extensions)
+        extension->preRender();
+}
+
+void PluginManager::postRender()
+{
+    for (const auto& extension : _extensions)
+        extension->postRender();
+}
+
+void PluginManager::_loadPlugin(PluginAPI* api, const char* name, int argc,
+                                const char* argv[])
+{
+    try
+    {
+        DynamicLib library(name);
+        auto createSym = library.getSymbolAddress("brayns_plugin_create");
+        if (!createSym)
+        {
+            throw std::runtime_error(
+                std::string("Plugin '") + name +
+                "' is not a valid Brayns plugin; missing " +
+                "brayns_plugin_create()");
+        }
+
+        CreateFuncType createFunc = (CreateFuncType)createSym;
+
+        _extensions.emplace_back(createFunc(api, argc, argv));
+        _libs.push_back(std::move(library));
+        BRAYNS_INFO << "Loaded plugin '" << name << "'" << std::endl;
+    }
+    catch (const std::runtime_error& exc)
+    {
+        BRAYNS_ERROR << exc.what() << std::endl;
+    }
+}
+}

--- a/brayns/PluginManager.cpp
+++ b/brayns/PluginManager.cpp
@@ -36,9 +36,9 @@
 
 namespace brayns
 {
-typedef ExtensionPlugin* (*CreateFuncType)(PluginAPI*, int, const char**);
+typedef ExtensionPlugin* (*CreateFuncType)(int, const char**);
 
-PluginManager::PluginManager(PluginAPI* api, int argc, const char** argv)
+PluginManager::PluginManager(int argc, const char** argv)
 {
     for (int i = 0; i < argc; ++i)
     {
@@ -62,7 +62,7 @@ PluginManager::PluginManager(PluginAPI* api, int argc, const char** argv)
         for (const auto& w : words)
             args.push_back(w.c_str());
 
-        _loadPlugin(api, name, args.size(), args.data());
+        _loadPlugin(name, args.size(), args.data());
     }
 }
 
@@ -115,8 +115,7 @@ void PluginManager::postRender()
         extension->postRender();
 }
 
-void PluginManager::_loadPlugin(PluginAPI* api, const char* name, int argc,
-                                const char* argv[])
+void PluginManager::_loadPlugin(const char* name, int argc, const char* argv[])
 {
     try
     {
@@ -132,7 +131,7 @@ void PluginManager::_loadPlugin(PluginAPI* api, const char* name, int argc,
 
         CreateFuncType createFunc = (CreateFuncType)createSym;
 
-        _extensions.emplace_back(createFunc(api, argc, argv));
+        _extensions.emplace_back(createFunc(argc, argv));
         _libs.push_back(std::move(library));
         BRAYNS_INFO << "Loaded plugin '" << name << "'" << std::endl;
     }

--- a/brayns/PluginManager.h
+++ b/brayns/PluginManager.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Daniel.Nachbaur@epfl.ch
+ * Responsible Author: Juan Hernando <cyrille.favreau@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -20,17 +20,39 @@
 
 #pragma once
 
-#include <brayns/common/tasks/Task.h>
+#include <brayns/common/types.h>
+#include <brayns/common/utils/DynamicLib.h>
+
+#include <vector>
 
 namespace brayns
 {
 /**
- * A task which loads data from the path of the given params and adds the loaded
- * model to the engines' scene.
  */
-class AddModelTask : public Task<ModelDescriptorPtr>
+class PluginManager
 {
 public:
-    AddModelTask(const ModelParams& model, Engine& engine);
+    /**
+     * @brief Constructor
+     * @param argc Number of command line arguments
+     * @param argv Command line arguments
+     */
+    PluginManager(PluginAPI* api, int argc, const char** argv);
+
+    /** Calls ExtensionPlugin::init in all loaded plugins */
+    void initPlugins(PluginAPI* api);
+
+    /** Calls ExtensionPlugin::preRender in all loaded plugins */
+    void preRender();
+
+    /** Calls ExtensionPlugin::postRender in all loaded plugins */
+    void postRender();
+
+private:
+    std::vector<DynamicLib> _libs;
+    std::vector<ExtensionPluginPtr> _extensions;
+
+    void _loadPlugin(PluginAPI* api, const char* name, int argc,
+                     const char* argv[]);
 };
 }

--- a/brayns/PluginManager.h
+++ b/brayns/PluginManager.h
@@ -37,7 +37,7 @@ public:
      * @param argc Number of command line arguments
      * @param argv Command line arguments
      */
-    PluginManager(PluginAPI* api, int argc, const char** argv);
+    PluginManager(int argc, const char** argv);
 
     /** Calls ExtensionPlugin::init in all loaded plugins */
     void initPlugins(PluginAPI* api);
@@ -52,7 +52,6 @@ private:
     std::vector<DynamicLib> _libs;
     std::vector<ExtensionPluginPtr> _extensions;
 
-    void _loadPlugin(PluginAPI* api, const char* name, int argc,
-                     const char* argv[]);
+    void _loadPlugin(const char* name, int argc, const char* argv[]);
 };
 }

--- a/brayns/common/types.h
+++ b/brayns/common/types.h
@@ -77,6 +77,7 @@ namespace brayns
 class Brayns;
 
 class ActionInterface;
+using ActionInterfacePtr = std::shared_ptr<ActionInterface>;
 
 class Engine;
 using EnginePtr = std::shared_ptr<Engine>;

--- a/brayns/parameters/ApplicationParameters.cpp
+++ b/brayns/parameters/ApplicationParameters.cpp
@@ -22,7 +22,6 @@
 #include <brayns/common/log.h>
 #include <brayns/parameters/ParametersManager.h>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 namespace
@@ -141,22 +140,6 @@ void ApplicationParameters::parse(const po::variables_map& vm)
         _imageStreamFPS = vm[PARAM_IMAGE_STREAM_FPS].as<size_t>();
     if (vm.count(PARAM_MAX_RENDER_FPS))
         _maxRenderFPS = vm[PARAM_MAX_RENDER_FPS].as<size_t>();
-
-    // Explode plugin arguments
-    for (auto pluginString : _pluginsRaw)
-    {
-        boost::trim(pluginString);
-        std::vector<std::string> words;
-        boost::split(words, pluginString, boost::is_any_of(" "),
-                     boost::token_compress_on);
-
-        PluginParam plugin;
-        plugin.name = words.front();
-        plugin.arguments =
-            std::vector<std::string>(words.begin() + 1, words.end());
-
-        _plugins.emplace_back(std::move(plugin));
-    }
 
     markModified();
 }

--- a/brayns/parameters/ApplicationParameters.h
+++ b/brayns/parameters/ApplicationParameters.h
@@ -31,12 +31,6 @@ SERIALIZATION_ACCESS(ApplicationParameters)
 
 namespace brayns
 {
-struct PluginParam
-{
-    std::string name;
-    std::vector<std::string> arguments;
-};
-
 /** Manages application parameters
  */
 class ApplicationParameters : public AbstractParameters
@@ -63,8 +57,6 @@ public:
         _updateValue(_dynamicLoadBalancer, value);
     }
 
-    /** Runtime plugins to load in Brayns::loadPlugins. */
-    const std::vector<PluginParam>& getPlugins() const { return _plugins; }
     /** window size */
     const Vector2ui getWindowSize() const { return Vector2ui(_windowSize); }
     void setWindowSize(const Vector2ui& size)
@@ -120,7 +112,6 @@ protected:
     EngineType _engine{EngineType::ospray};
     std::vector<std::string> _modules;
     strings _pluginsRaw;
-    std::vector<PluginParam> _plugins;
     Vector2d _windowSize;
     bool _benchmarking{false};
     size_t _jpegCompression;

--- a/brayns/pluginapi/ExtensionPlugin.h
+++ b/brayns/pluginapi/ExtensionPlugin.h
@@ -21,8 +21,13 @@
 #ifndef EXTENSIONPLUGIN_H
 #define EXTENSIONPLUGIN_H
 
+#include <brayns/common/types.h>
+
 namespace brayns
 {
+
+class Engine;
+
 /**
  * Defines the abstract representation of an extension plug-in. What we mean by
  * extension is a set a functionalities that are not provided by the core of the
@@ -45,6 +50,11 @@ class ExtensionPlugin
 {
 public:
     virtual ~ExtensionPlugin() = default;
+
+    /**
+     * Called from Brayns::Brayns right after the engine has been created
+     */
+    virtual void init(PluginAPI* /* api */) {}
 
     /**
      * Called from Brayns::preRender() to prepare the engine based on the

--- a/brayns/pluginapi/PluginAPI.h
+++ b/brayns/pluginapi/PluginAPI.h
@@ -31,6 +31,8 @@ class PluginAPI
 public:
     virtual ~PluginAPI() = default;
 
+    virtual Engine& getEngine() = 0;
+
     /** @return access to the scene of Brayns. */
     virtual Scene& getScene() = 0;
 
@@ -54,5 +56,8 @@ public:
 
     /** Triggers a new preRender() and potentially render() and postRender(). */
     virtual void triggerRender() = 0;
+
+    /** Set the action interface to be used by Brayns main loop. */
+    virtual void setActionInterface(const ActionInterfacePtr& interface) = 0;
 };
 }

--- a/brayns/tasks/AddModelFromBlobTask.cpp
+++ b/brayns/tasks/AddModelFromBlobTask.cpp
@@ -31,7 +31,7 @@
 namespace brayns
 {
 AddModelFromBlobTask::AddModelFromBlobTask(const BinaryParam& param,
-                                           EnginePtr engine)
+                                           Engine& engine)
     : _param(param)
 {
     _checkValidity(engine);
@@ -78,12 +78,12 @@ void AddModelFromBlobTask::appendBlob(const std::string& blob)
         _chunkEvent.set({_param.type, _param.getName(), std::move(_blob)});
 }
 
-void AddModelFromBlobTask::_checkValidity(EnginePtr engine)
+void AddModelFromBlobTask::_checkValidity(Engine& engine)
 {
     if (_param.type.empty() || _param.size == 0)
         throw MISSING_PARAMS;
 
-    const auto& registry = engine->getScene().getLoaderRegistry();
+    const auto& registry = engine.getScene().getLoaderRegistry();
     if (!registry.isSupportedType(_param.type))
         throw UNSUPPORTED_TYPE;
 }

--- a/brayns/tasks/AddModelFromBlobTask.h
+++ b/brayns/tasks/AddModelFromBlobTask.h
@@ -51,12 +51,12 @@ struct BinaryParam : ModelParams
 class AddModelFromBlobTask : public Task<ModelDescriptorPtr>
 {
 public:
-    AddModelFromBlobTask(const BinaryParam& param, EnginePtr engine);
+    AddModelFromBlobTask(const BinaryParam& param, Engine& engine);
 
     void appendBlob(const std::string& blob);
 
 private:
-    void _checkValidity(EnginePtr engine);
+    void _checkValidity(Engine& engine);
     void _cancel() final
     {
         _chunkEvent.set_exception(

--- a/brayns/tasks/AddModelTask.cpp
+++ b/brayns/tasks/AddModelTask.cpp
@@ -29,9 +29,9 @@
 
 namespace brayns
 {
-AddModelTask::AddModelTask(const ModelParams& modelParams, EnginePtr engine)
+AddModelTask::AddModelTask(const ModelParams& modelParams, Engine& engine)
 {
-    const auto& registry = engine->getScene().getLoaderRegistry();
+    const auto& registry = engine.getScene().getLoaderRegistry();
 
     // pre-check for validity of given paths
     const auto& path = modelParams.getPath();

--- a/brayns/tasks/LoadModelFunctor.cpp
+++ b/brayns/tasks/LoadModelFunctor.cpp
@@ -38,7 +38,7 @@ namespace brayns
 {
 const float TOTAL_PROGRESS = 100.f;
 
-LoadModelFunctor::LoadModelFunctor(EnginePtr engine, const ModelParams& params)
+LoadModelFunctor::LoadModelFunctor(Engine& engine, const ModelParams& params)
     : _engine(engine)
     , _params(params)
 {
@@ -73,15 +73,15 @@ ModelDescriptorPtr LoadModelFunctor::_performLoad(
 ModelDescriptorPtr LoadModelFunctor::_loadData(Blob&& blob,
                                                const ModelParams& params)
 {
-    return _engine->getScene().loadModel(std::move(blob), NO_MATERIAL, params,
-                                         {_getProgressFunc()});
+    return _engine.getScene().loadModel(std::move(blob), NO_MATERIAL, params,
+                                        {_getProgressFunc()});
 }
 
 ModelDescriptorPtr LoadModelFunctor::_loadData(const std::string& path,
                                                const ModelParams& params)
 {
-    return _engine->getScene().loadModel(path, NO_MATERIAL, params,
-                                         {_getProgressFunc()});
+    return _engine.getScene().loadModel(path, NO_MATERIAL, params,
+                                        {_getProgressFunc()});
 }
 
 void LoadModelFunctor::_updateProgress(const std::string& message,

--- a/brayns/tasks/LoadModelFunctor.h
+++ b/brayns/tasks/LoadModelFunctor.h
@@ -33,7 +33,7 @@ namespace brayns
 class LoadModelFunctor : public TaskFunctor
 {
 public:
-    LoadModelFunctor(EnginePtr engine, const ModelParams& params);
+    LoadModelFunctor(Engine& engine, const ModelParams& params);
     LoadModelFunctor(LoadModelFunctor&&) = default;
     ModelDescriptorPtr operator()(Blob&& blob);
     ModelDescriptorPtr operator()();
@@ -50,7 +50,7 @@ private:
 
     std::function<void(std::string, float)> _getProgressFunc();
 
-    EnginePtr _engine;
+    Engine& _engine;
     ModelParams _params;
     size_t _currentProgress{0};
     size_t _nextTic{0};

--- a/plugins/Deflect/DeflectPlugin.h
+++ b/plugins/Deflect/DeflectPlugin.h
@@ -30,7 +30,7 @@ namespace brayns
 class DeflectPlugin : public ExtensionPlugin
 {
 public:
-    DeflectPlugin(EnginePtr engine, PluginAPI* api);
+    BRAYNS_API void init(PluginAPI* api) final;
 
     /** Handle stream setup and incoming events. */
     BRAYNS_API void preRender() final;

--- a/plugins/Example/Plugin.cpp
+++ b/plugins/Example/Plugin.cpp
@@ -21,13 +21,17 @@
 
 namespace brayns
 {
-ExamplePlugin::ExamplePlugin(PluginAPI* api, int argc, const char** argv)
-    : _api(api)
+ExamplePlugin::ExamplePlugin(int argc, const char** argv)
 {
     std::cout << "Got args: ";
     for (int i = 0; i < argc; ++i)
         std::cout << argv[i] << "; ";
     std::cout << std::endl;
+}
+
+void ExamplePlugin::init(PluginAPI* api)
+{
+    std::cout << "Plugin init" << std::endl;
 }
 
 void ExamplePlugin::preRender()
@@ -46,9 +50,8 @@ void ExamplePlugin::postSceneLoading()
 }
 }
 
-extern "C" brayns::ExtensionPlugin* brayns_plugin_create(brayns::PluginAPI* api,
-                                                         int argc,
+extern "C" brayns::ExtensionPlugin* brayns_plugin_create(int argc,
                                                          const char** argv)
 {
-    return new brayns::ExamplePlugin(api, argc, argv);
+    return new brayns::ExamplePlugin(argc, argv);
 }

--- a/plugins/Example/Plugin.h
+++ b/plugins/Example/Plugin.h
@@ -26,13 +26,11 @@ namespace brayns
 class ExamplePlugin : public ExtensionPlugin
 {
 public:
-    ExamplePlugin(PluginAPI* api, int argc, char** argv);
+    ExamplePlugin(int argc, char** argv);
 
+    void init(PluginAPI* api) final;
     void preRender() final;
     void postRender() final;
     void postSceneLoading() final;
-
-private:
-    PluginAPI* _api;
 };
 }

--- a/plugins/Rockets/BinaryRequests.h
+++ b/plugins/Rockets/BinaryRequests.h
@@ -42,7 +42,7 @@ public:
      * binary data to delegate them to the task.
      */
     auto createTask(const BinaryParam& param, uintptr_t clientID,
-                    EnginePtr engine)
+                    Engine& engine)
     {
         auto task = std::make_shared<AddModelFromBlobTask>(param, engine);
 

--- a/plugins/Rockets/RocketsPlugin.h
+++ b/plugins/Rockets/RocketsPlugin.h
@@ -33,10 +33,10 @@ namespace brayns
    the outside world. The http server is configured according
    to the --http-server parameter provided by ApplicationParameters.
  */
-class RocketsPlugin : public ExtensionPlugin, public ActionInterface
+class RocketsPlugin : public ExtensionPlugin
 {
 public:
-    RocketsPlugin(EnginePtr engine, PluginAPI* api);
+    void init(PluginAPI* api) final;
 
     /**
      * In case no event loop is available, this processes in- and outgoing HTTP
@@ -56,28 +56,6 @@ public:
 private:
     class Impl;
     std::shared_ptr<Impl> _impl;
-
-    void registerNotification(
-        const RpcParameterDescription& desc, const PropertyMap& input,
-        const std::function<void(PropertyMap)>& action) final;
-
-    void registerNotification(const RpcDescription& desc,
-                              const std::function<void()>& action) final;
-    void registerRequest(
-        const RpcParameterDescription& desc, const PropertyMap& input,
-        const PropertyMap& output,
-        const std::function<PropertyMap(PropertyMap)>& action) final;
-
-    void registerRequest(const RpcDescription& desc, const PropertyMap& output,
-                         const std::function<PropertyMap()>& action) final;
-
-    void _registerRequest(const std::string& name,
-                          const RetParamFunc& action) final;
-    void _registerRequest(const std::string& name, const RetFunc& action) final;
-    void _registerNotification(const std::string& name,
-                               const ParamFunc& action) final;
-    void _registerNotification(const std::string& name,
-                               const VoidFunc& action) final;
 };
 }
 

--- a/tests/myPlugin.cpp
+++ b/tests/myPlugin.cpp
@@ -35,7 +35,7 @@ const Vec2 vecVal{{1, 1}};
 class MyPlugin : public brayns::ExtensionPlugin
 {
 public:
-    MyPlugin(brayns::PluginAPI* api, int argc, const char** argv)
+    MyPlugin(const int argc, const char** argv)
     {
         if (argc > 0)
         {
@@ -44,7 +44,10 @@ public:
                 std::cout << " " << std::string(argv[i]);
             std::cout << std::endl;
         }
+    }
 
+    void init(brayns::PluginAPI* api) final
+    {
         auto actions = api->getActionInterface();
         BOOST_REQUIRE(actions);
 
@@ -132,5 +135,5 @@ extern "C" brayns::ExtensionPlugin* brayns_plugin_create(brayns::PluginAPI* api,
                                                          int argc,
                                                          const char** argv)
 {
-    return new MyPlugin(api, argc, argv);
+    return new MyPlugin(argc, argv);
 }

--- a/tests/myPlugin.cpp
+++ b/tests/myPlugin.cpp
@@ -131,8 +131,7 @@ public:
 
 OSP_REGISTER_RENDERER(MyRenderer, myrenderer);
 
-extern "C" brayns::ExtensionPlugin* brayns_plugin_create(brayns::PluginAPI* api,
-                                                         int argc,
+extern "C" brayns::ExtensionPlugin* brayns_plugin_create(int argc,
                                                          const char** argv)
 {
     return new MyPlugin(argc, argv);


### PR DESCRIPTION
This is one step towards being able to extend command line parsing
with plugin specific options. As a requirement to it we need to load
plugins before parsing takes place.

Plugin handling has been moved to a separate class called PluginManager.

Registration of notification callbacks moved to the implementation in
the Rockets plugin.