### PR TITLE
Moved command line parsing for circuits and morphologies to plugin

### DIFF
--- a/brayns/common/types.h
+++ b/brayns/common/types.h
@@ -203,17 +203,10 @@ enum class FrameBufferFormat
 enum class ColorScheme
 {
     none = 0,
-    neuron_by_id = 1,
-    neuron_by_type = 2,
-    neuron_by_segment_type = 3,
-    neuron_by_layer = 4,
-    neuron_by_mtype = 5,
-    neuron_by_etype = 6,
-    neuron_by_target = 7,
-    protein_by_id = 8,
-    protein_atoms = 9,
-    protein_chains = 10,
-    protein_residues = 11
+    by_id = 1,
+    protein_atoms = 2,
+    protein_chains = 3,
+    protein_residues = 4
 };
 
 /** Geometry quality */
@@ -223,26 +216,6 @@ enum class GeometryQuality
     medium,
     high
 };
-
-/** Morphology element types */
-enum class MorphologySectionType
-{
-    soma = 0x01,
-    axon = 0x02,
-    dendrite = 0x04,
-    apical_dendrite = 0x08,
-    all = 0xff
-};
-using MorphologySectionTypes = std::vector<MorphologySectionType>;
-
-template <typename T>
-size_t enumsToBitmask(const std::vector<T> enums)
-{
-    size_t bit{0};
-    for (auto& val : enums)
-        bit |= size_t(val);
-    return bit;
-}
 
 /** Some 'special' materials are used by Brayns to accomplish specific features
  *  such as bounding boxes.
@@ -384,14 +357,7 @@ template <>
 inline std::vector<std::pair<std::string, ColorScheme>> enumMap()
 {
     return {{"none", ColorScheme::none},
-            {"neuron_by_id", ColorScheme::neuron_by_id},
-            {"neuron_by_type", ColorScheme::neuron_by_type},
-            {"neuron_by_segment_type", ColorScheme::neuron_by_segment_type},
-            {"neuron_by_layer", ColorScheme::neuron_by_layer},
-            {"neuron_by_mtype", ColorScheme::neuron_by_mtype},
-            {"neuron_by_etype", ColorScheme::neuron_by_etype},
-            {"neuron_by_target", ColorScheme::neuron_by_target},
-            {"protein_by_id", ColorScheme::protein_by_id},
+            {"by_id", ColorScheme::by_id},
             {"protein_atoms", ColorScheme::protein_atoms},
             {"protein_chains", ColorScheme::protein_chains},
             {"protein_residues", ColorScheme::protein_residues}};

--- a/brayns/io/MeshLoader.h
+++ b/brayns/io/MeshLoader.h
@@ -40,6 +40,7 @@ class MeshLoader : public Loader
 {
 public:
     MeshLoader(Scene& scene);
+    MeshLoader(Scene& scene, const GeometryParameters& geom);
 
     std::vector<std::string> getSupportedExtensions() const final;
     std::string getName() const final;
@@ -59,20 +60,19 @@ public:
         const size_t defaultMaterial = NO_MATERIAL) const final;
 
     void importMesh(const std::string& fileName, const LoaderProgress& callback,
-                    Model& model, const size_t index,
-                    const Matrix4f& transformation,
+                    Model& model, const Matrix4f& transformation,
                     const size_t defaultMaterialId,
-                    const ColorScheme colorScheme,
                     const GeometryQuality geometryQuality) const;
 
 private:
+    PropertyMap _defaults;
+
     void _createMaterials(Model& model, const aiScene* aiScene,
                           const std::string& folder) const;
 
-    void _postLoad(const aiScene* aiScene, Model& model, const size_t index,
+    void _postLoad(const aiScene* aiScene, Model& model,
                    const Matrix4f& transformation, const size_t defaultMaterial,
-                   const std::string& folder,
-                   const ColorScheme colorScheme) const;
+                   const std::string& folder) const;
     size_t _getQuality(const GeometryQuality geometryQuality) const;
 };
 }

--- a/brayns/io/MolecularSystemReader.h
+++ b/brayns/io/MolecularSystemReader.h
@@ -21,6 +21,8 @@
 #ifndef MOLECULARSYSTEMREADER_H
 #define MOLECULARSYSTEMREADER_H
 
+#include "ProteinLoader.h"
+
 #include <brayns/common/loader/Loader.h>
 #include <brayns/common/types.h>
 #include <set>
@@ -51,7 +53,7 @@ typedef std::map<size_t, Vector3fs> ProteinPositions;
 class MolecularSystemReader : public Loader
 {
 public:
-    MolecularSystemReader(Scene& scene);
+    MolecularSystemReader(Scene& scene, const GeometryParameters& params);
 
     std::vector<std::string> getSupportedExtensions() const final;
     std::string getName() const final;
@@ -86,6 +88,9 @@ private:
         ProteinPositions _proteinPositions;
         LoaderProgress _callback;
     };
+
+    PropertyMap _defaults;
+    ProteinLoader _proteinLoader;
 
     bool _createScene(LoaderData& data,
                       const PropertyMap& properties) const;

--- a/brayns/io/ProteinLoader.h
+++ b/brayns/io/ProteinLoader.h
@@ -34,7 +34,7 @@ namespace brayns
 class ProteinLoader : public Loader
 {
 public:
-    ProteinLoader(Scene& scene);
+    ProteinLoader(Scene& scene, const GeometryParameters& params);
 
     std::vector<std::string> getSupportedExtensions() const final;
     std::string getName() const final;
@@ -54,6 +54,9 @@ public:
     {
         throw std::runtime_error("Loading from blob not supported");
     }
+
+private:
+    PropertyMap _defaults;
 };
 }
 

--- a/brayns/parameters/GeometryParameters.cpp
+++ b/brayns/parameters/GeometryParameters.cpp
@@ -27,42 +27,16 @@
 
 namespace
 {
-const std::string PARAM_CIRCUIT_DENSITY = "circuit-density";
-const std::string PARAM_CIRCUIT_USES_SIMULATION_MODEL =
-    "circuit-uses-simulation-model";
-const std::string PARAM_CIRCUIT_MESH_FOLDER = "circuit-mesh-folder";
-const std::string PARAM_CIRCUIT_MESH_FILENAME_PATTERN =
-    "circuit-mesh-filename-pattern";
-const std::string PARAM_CIRCUIT_TRANSFORM_MESHES =
-    "circuit-transform-meshes";
-const std::string PARAM_CIRCUIT_TARGETS = "circuit-targets";
-const std::string PARAM_CIRCUIT_REPORT = "circuit-report";
-const std::string PARAM_CIRCUIT_START_SIMULATION_TIME =
-    "circuit-start-simulation-time";
-const std::string PARAM_CIRCUIT_END_SIMULATION_TIME =
-    "circuit-end-simulation-time";
-const std::string PARAM_CIRCUIT_SIMULATION_STEP = "circuit-simulation-step";
-const std::string PARAM_CIRCUIT_SIMULATION_RANGE =
-    "circuit-simulation-values-range";
-const std::string PARAM_CIRCUIT_RANDOM_SEED = "circuit-random-seed";
 const std::string PARAM_LOAD_CACHE_FILE = "load-cache-file";
 const std::string PARAM_SAVE_CACHE_FILE = "save-cache-file";
-const std::string PARAM_RADIUS_MULTIPLIER = "radius-multiplier";
-const std::string PARAM_RADIUS_CORRECTION = "radius-correction";
 const std::string PARAM_COLOR_SCHEME = "color-scheme";
 const std::string PARAM_GEOMETRY_QUALITY = "geometry-quality";
-const std::string PARAM_MORPHOLOGY_SECTION_TYPES = "morphology-section-types";
-const std::string PARAM_MORPHOLOGY_DAMPEN_BRANCH_THICKNESS_CHANGERATE =
-    "morphology-dampen-branch-thickness-changerate";
-const std::string PARAM_MORPHOLOGY_USE_SDF_GEOMETRIES =
-    "morphology-use-sdf-geometries";
+const std::string PARAM_RADIUS_MULTIPLIER = "radius-multiplier";
 const std::string PARAM_MEMORY_MODE = "memory-mode";
 const std::string PARAM_DEFAULT_BVH_FLAG = "default-bvh-flag";
 
-const std::array<std::string, 12> COLOR_SCHEMES = {
-    {"none", "neuron-by-id", "neuron-by-type", "neuron-by-segment-type",
-     "neuron-by-layer", "neuron-by-mtype", "neuron-by-etype",
-     "neuron-by-target", "protein-by-id", "protein-atoms", "protein-chains",
+const std::array<std::string, 5> COLOR_SCHEMES = {{
+     "none", "by-id", "protein-atoms", "protein-chains",
      "protein-residues"}};
 
 const std::string GEOMETRY_QUALITIES[3] = {"low", "medium", "high"};
@@ -77,14 +51,6 @@ namespace brayns
 {
 GeometryParameters::GeometryParameters()
     : AbstractParameters("Geometry")
-    , _radiusMultiplier(1.f)
-    , _radiusCorrection(0.f)
-    , _colorScheme(ColorScheme::none)
-    , _geometryQuality(GeometryQuality::high)
-    , _morphologySectionTypes{MorphologySectionType::all}
-    , _morphologyDampenBranchThicknessChangerate(false)
-    , _morphologyUseSdfGeometries(false)
-    , _memoryMode(MemoryMode::shared)
 {
     _parameters.add_options() //
         (PARAM_LOAD_CACHE_FILE.c_str(), po::value<std::string>(),
@@ -93,82 +59,19 @@ GeometryParameters::GeometryParameters()
         (PARAM_SAVE_CACHE_FILE.c_str(), po::value<std::string>(),
          "Save binary container of a scene [string]")
         //
-        (PARAM_RADIUS_MULTIPLIER.c_str(), po::value<float>(),
-         "Radius multiplier for spheres, cones and cylinders [float]")
-        //
-        (PARAM_RADIUS_CORRECTION.c_str(), po::value<float>(),
-         "Forces radius of spheres and cylinders to the specified value "
-         "[float]")
-        //
         (PARAM_COLOR_SCHEME.c_str(), po::value<std::string>(),
          "Color scheme to be applied to the geometry "
-         "[none|neuron-by-id|neuron-by-type|neuron-by-segment-type|"
-         "neuron-by-layer|neuron-by-mtype|neuron-by-etype|neuron-by-"
-         "target|protein-by-id|protein-atoms|protein-chains|protein-"
-         "residues]")
+         "[none|by-id|protein-atoms|protein-chains|protein-residues]")
         //
         (PARAM_GEOMETRY_QUALITY.c_str(), po::value<std::string>(),
          "Geometry rendering quality [low|medium|high]")
         //
-        (PARAM_CIRCUIT_TARGETS.c_str(), po::value<std::string>(),
-         "Circuit targets [comma separated strings]")
-        //
-        (PARAM_CIRCUIT_DENSITY.c_str(), po::value<float>(),
-         "Density of cells in the circuit in percent [float]")
-        //
-        (PARAM_CIRCUIT_MESH_FOLDER.c_str(), po::value<std::string>(),
-         "Folder containing meshed morphologies [string]")
-        //
-        (PARAM_CIRCUIT_REPORT.c_str(), po::value<std::string>(),
-         "Circuit report [string]")
-        //
-        (PARAM_MORPHOLOGY_SECTION_TYPES.c_str(), po::value<size_t>(),
-         "Morphology section types (1: soma, 2: axon, 4: dendrite, "
-         "8: apical dendrite). Values can be added to select more than "
-         "one type of section")
-        //
-        (PARAM_CIRCUIT_START_SIMULATION_TIME.c_str(), po::value<double>(),
-         "Start simulation timestamp [double]")
-        //
-        (PARAM_CIRCUIT_END_SIMULATION_TIME.c_str(), po::value<double>(),
-         "End simulation timestamp [double]")
-        //
-        (PARAM_CIRCUIT_SIMULATION_STEP.c_str(), po::value<double>(),
-         "Step between simulation frames [double]")
-        //
-        (PARAM_CIRCUIT_SIMULATION_RANGE.c_str(),
-         po::value<floats>()->multitoken(),
-         "Minimum and maximum values for the simulation [float float]")
-        //
-        (PARAM_CIRCUIT_RANDOM_SEED.c_str(), po::value<size_t>(),
-         "Random seed for circuit [int]")
-        //
-        (PARAM_MORPHOLOGY_DAMPEN_BRANCH_THICKNESS_CHANGERATE.c_str(),
-         po::bool_switch()->default_value(false),
-         "Dampen the thickness rate of change for branches in the morphology.")
-        //
-        (PARAM_MORPHOLOGY_USE_SDF_GEOMETRIES.c_str(),
-         po::bool_switch()->default_value(false),
-         "Use SDF geometries for drawing the morphologies.")
-        //
-        (PARAM_CIRCUIT_USES_SIMULATION_MODEL.c_str(),
-         po::bool_switch()->default_value(false),
-         "Defines if a different model is used to handle the simulation "
-         "geometry.")
+        (PARAM_RADIUS_MULTIPLIER.c_str(), po::value<float>(),
+         "Radius multiplier for spheres, cones and cylinders [float]")
         //
         (PARAM_MEMORY_MODE.c_str(), po::value<std::string>(),
          "Defines what memory mode should be used between Brayns and "
-         "the "
-         "underlying renderer [shared|replicated]")
-        //
-        (PARAM_CIRCUIT_MESH_FILENAME_PATTERN.c_str(), po::value<std::string>(),
-         "Pattern used to determine the name of the file containing a "
-         "meshed "
-         "morphology [string]")
-        //
-        (PARAM_CIRCUIT_TRANSFORM_MESHES.c_str(),
-         po::bool_switch()->default_value(false),
-         "Enable mesh transformation according to circuit information.")
+         "the underlying renderer [shared|replicated]")
         //
         (PARAM_DEFAULT_BVH_FLAG.c_str(),
          po::value<std::vector<std::string>>()->multitoken(),
@@ -197,10 +100,6 @@ void GeometryParameters::parse(const po::variables_map& vm)
             _colorScheme = static_cast<ColorScheme>(index);
         }
     }
-    if (vm.count(PARAM_RADIUS_MULTIPLIER))
-        _radiusMultiplier = vm[PARAM_RADIUS_MULTIPLIER].as<float>();
-    if (vm.count(PARAM_RADIUS_CORRECTION))
-        _radiusCorrection = vm[PARAM_RADIUS_CORRECTION].as<float>();
     if (vm.count(PARAM_GEOMETRY_QUALITY))
     {
         _geometryQuality = GeometryQuality::low;
@@ -212,57 +111,8 @@ void GeometryParameters::parse(const po::variables_map& vm)
             if (geometryQuality == GEOMETRY_QUALITIES[i])
                 _geometryQuality = static_cast<GeometryQuality>(i);
     }
-    if (vm.count(PARAM_CIRCUIT_TARGETS))
-        _circuitConfiguration.targets =
-            vm[PARAM_CIRCUIT_TARGETS].as<std::string>();
-    if (vm.count(PARAM_CIRCUIT_REPORT))
-        _circuitConfiguration.report =
-            vm[PARAM_CIRCUIT_REPORT].as<std::string>();
-    if (vm.count(PARAM_CIRCUIT_DENSITY))
-        _circuitConfiguration.density = vm[PARAM_CIRCUIT_DENSITY].as<float>();
-    if (vm.count(PARAM_CIRCUIT_MESH_FOLDER))
-        _circuitConfiguration.meshFolder =
-            vm[PARAM_CIRCUIT_MESH_FOLDER].as<std::string>();
-    if (vm.count(PARAM_MORPHOLOGY_SECTION_TYPES))
-    {
-        _morphologySectionTypes.clear();
-        const auto bits = vm[PARAM_MORPHOLOGY_SECTION_TYPES].as<size_t>();
-        if (bits & size_t(MorphologySectionType::soma))
-            _morphologySectionTypes.push_back(MorphologySectionType::soma);
-        if (bits & size_t(MorphologySectionType::axon))
-            _morphologySectionTypes.push_back(MorphologySectionType::axon);
-        if (bits & size_t(MorphologySectionType::dendrite))
-            _morphologySectionTypes.push_back(MorphologySectionType::dendrite);
-        if (bits & size_t(MorphologySectionType::apical_dendrite))
-            _morphologySectionTypes.push_back(
-                MorphologySectionType::apical_dendrite);
-    }
-    if (vm.count(PARAM_CIRCUIT_START_SIMULATION_TIME))
-        _circuitConfiguration.startSimulationTime =
-            vm[PARAM_CIRCUIT_START_SIMULATION_TIME].as<double>();
-    if (vm.count(PARAM_CIRCUIT_END_SIMULATION_TIME))
-        _circuitConfiguration.endSimulationTime =
-            vm[PARAM_CIRCUIT_END_SIMULATION_TIME].as<double>();
-    if (vm.count(PARAM_CIRCUIT_SIMULATION_STEP))
-        _circuitConfiguration.simulationStep =
-            vm[PARAM_CIRCUIT_SIMULATION_STEP].as<double>();
-    if (vm.count(PARAM_CIRCUIT_SIMULATION_RANGE))
-    {
-        floats values = vm[PARAM_CIRCUIT_SIMULATION_RANGE].as<floats>();
-        if (values.size() == 2)
-            _circuitConfiguration.simulationValuesRange =
-                Vector2f(values[0], values[1]);
-    }
-    if (vm.count(PARAM_CIRCUIT_RANDOM_SEED))
-        _circuitConfiguration.randomSeed =
-            vm[PARAM_CIRCUIT_RANDOM_SEED].as<size_t>();
-
-    _morphologyDampenBranchThicknessChangerate =
-        vm[PARAM_MORPHOLOGY_DAMPEN_BRANCH_THICKNESS_CHANGERATE].as<bool>();
-    _morphologyUseSdfGeometries =
-        vm[PARAM_MORPHOLOGY_USE_SDF_GEOMETRIES].as<bool>();
-    _circuitConfiguration.useSimulationModel =
-        vm[PARAM_CIRCUIT_USES_SIMULATION_MODEL].as<bool>();
+    if (vm.count(PARAM_RADIUS_MULTIPLIER))
+        _radiusMultiplier = vm[PARAM_RADIUS_MULTIPLIER].as<float>();
     if (vm.count(PARAM_MEMORY_MODE))
     {
         const auto& memoryMode = vm[PARAM_MEMORY_MODE].as<std::string>();
@@ -272,12 +122,6 @@ void GeometryParameters::parse(const po::variables_map& vm)
             if (memoryMode == GEOMETRY_MEMORY_MODES[i])
                 _memoryMode = static_cast<MemoryMode>(i);
     }
-    if (vm.count(PARAM_CIRCUIT_MESH_FILENAME_PATTERN))
-        _circuitConfiguration.meshFilenamePattern =
-            vm[PARAM_CIRCUIT_MESH_FILENAME_PATTERN].as<std::string>();
-    _circuitConfiguration.transformMeshes =
-        vm[PARAM_CIRCUIT_TRANSFORM_MESHES].as<bool>();
-
     if (vm.count(PARAM_DEFAULT_BVH_FLAG))
     {
         const auto& bvhs =
@@ -303,69 +147,15 @@ void GeometryParameters::print()
     BRAYNS_INFO << "Cache file to save         : " << _saveCacheFile
                 << std::endl;
     BRAYNS_INFO << "Color scheme               : "
-                << getColorSchemeAsString(_colorScheme) << std::endl;
-    BRAYNS_INFO << "Radius multiplier          : " << _radiusMultiplier
-                << std::endl;
-    BRAYNS_INFO << "Radius correction          : " << _radiusCorrection
+                << COLOR_SCHEMES[static_cast<size_t>(_colorScheme)]
                 << std::endl;
     BRAYNS_INFO << "Geometry quality           : "
-                << getGeometryQualityAsString(_geometryQuality) << std::endl;
-    BRAYNS_INFO << "Circuit configuration      : " << std::endl;
-    BRAYNS_INFO << " - Targets                 : "
-                << _circuitConfiguration.targets << std::endl;
-    BRAYNS_INFO << " - Report                  : "
-                << _circuitConfiguration.report << std::endl;
-    BRAYNS_INFO << " - Mesh folder             : "
-                << _circuitConfiguration.meshFolder << std::endl;
-    BRAYNS_INFO << " - Density                 : "
-                << _circuitConfiguration.density << std::endl;
-    BRAYNS_INFO << " - Start simulation time   : "
-                << _circuitConfiguration.startSimulationTime << std::endl;
-    BRAYNS_INFO << " - End simulation time     : "
-                << _circuitConfiguration.endSimulationTime << std::endl;
-    BRAYNS_INFO << " - Simulation step         : "
-                << _circuitConfiguration.simulationStep << std::endl;
-    BRAYNS_INFO << " - Simulation values range : "
-                << _circuitConfiguration.simulationValuesRange << std::endl;
-    BRAYNS_INFO << " - Transform meshes        : "
-                << (_circuitConfiguration.transformMeshes ? "Yes" : "No")
+                << GEOMETRY_QUALITIES[static_cast<size_t>(_geometryQuality)]
                 << std::endl;
-    BRAYNS_INFO << "Morphology section types   : "
-                << enumsToBitmask(_morphologySectionTypes) << std::endl;
-    BRAYNS_INFO << "Use simulation model       : "
-                << (_circuitConfiguration.useSimulationModel ? "Yes" : "No")
+    BRAYNS_INFO << "Radius multiplier          : " << _radiusMultiplier
                 << std::endl;
     BRAYNS_INFO << "Memory mode                : "
                 << (_memoryMode == MemoryMode::shared ? "Shared" : "Replicated")
                 << std::endl;
-    BRAYNS_INFO << "Mesh filename pattern      : "
-                << _circuitConfiguration.meshFilenamePattern << std::endl;
-}
-
-const std::string& GeometryParameters::getColorSchemeAsString(
-    const ColorScheme value) const
-{
-    return COLOR_SCHEMES[static_cast<size_t>(value)];
-}
-const std::string& GeometryParameters::getGeometryQualityAsString(
-    const GeometryQuality value) const
-{
-    return GEOMETRY_QUALITIES[static_cast<size_t>(value)];
-}
-
-double GeometryParameters::getCircuitDensity() const
-{
-    return std::max(0., std::min(100., _circuitConfiguration.density));
-}
-
-strings GeometryParameters::getCircuitTargetsAsStrings() const
-{
-    strings targets;
-    boost::char_separator<char> separator(",");
-    boost::tokenizer<boost::char_separator<char>> tokens(
-        _circuitConfiguration.targets, separator);
-    for_each(tokens.begin(), tokens.end(),
-             [&targets](const std::string& s) { targets.push_back(s); });
-    return targets;
 }
 }

--- a/brayns/parameters/GeometryParameters.h
+++ b/brayns/parameters/GeometryParameters.h
@@ -29,23 +29,6 @@ SERIALIZATION_ACCESS(GeometryParameters)
 
 namespace brayns
 {
-struct CircuitConfiguration
-{
-    bool useSimulationModel{false};
-    double density{100};
-    std::string meshFilenamePattern;
-    std::string meshFolder;
-    std::string targets;
-    std::string report;
-    double startSimulationTime{0};
-    double endSimulationTime{std::numeric_limits<float>::max()};
-    double simulationStep{0};
-    Vector2d simulationValuesRange{std::numeric_limits<double>::max(),
-                                   std::numeric_limits<double>::min()};
-    size_t randomSeed = 0;
-    bool transformMeshes{false};
-};
-
 /** Manages geometry parameters
  */
 class GeometryParameters : public AbstractParameters
@@ -63,132 +46,15 @@ public:
     const std::string& getLoadCacheFile() const { return _loadCacheFile; }
     /** Binary representation of a scene to save */
     const std::string& getSaveCacheFile() const { return _saveCacheFile; }
-    /** Circuit targets */
-    const std::string& getCircuitTargets() const
-    {
-        return _circuitConfiguration.targets;
-    }
-    strings getCircuitTargetsAsStrings() const;
-    /** Circuit compartment report */
-    const std::string& getCircuitReport() const
-    {
-        return _circuitConfiguration.report;
-    }
-    /** Defines the folder where morphologies meshes are stored. Meshes must
-     * have the same name as the h5/SWC morphology file, suffixed with an
-     * extension supported by the assimp library
-     */
-    const std::string& getCircuitMeshFolder() const
-    {
-        return _circuitConfiguration.meshFolder;
-    }
-    /** ensity of cells in the circuit in percent (Mainly for testing
-     * purposes) */
-    double getCircuitDensity() const;
-
-    /**
-     * Defines if a different model is used to handle the simulation geometry.
-     * If set to True, the shading of the main geometry model will be done
-     * using information stored in a secondary model that contains the
-     * simulation information. See OSPRay simulation renderer for more details.
-     */
-    bool getCircuitUseSimulationModel() const
-    {
-        return _circuitConfiguration.useSimulationModel;
-    }
-    void setCircuitUseSimulationModel(const bool value)
-    {
-        _updateValue(_circuitConfiguration.useSimulationModel, value);
-    }
-    /**
-     * Return the filename pattern use to load meshes
-     */
-    const std::string& getCircuitMeshFilenamePattern() const
-    {
-        return _circuitConfiguration.meshFilenamePattern;
-    }
-    /** Radius multiplier applied to spheres, cones and cylinders.
-     * @param value Radius multiplier. Multiplies the radius contained in the
-     *        data source by the specified value.
-     */
-    void setRadiusMultiplier(const float value)
-    {
-        _updateValue(_radiusMultiplier, value);
-    }
-    float getRadiusMultiplier() const { return _radiusMultiplier; }
-    /** Radius correction applied to spheres and cylinders.
-     * @param value Radius value. The radius contained in the data source is
-     *        ignored and all geometries use the specified value.
-     */
-    void setRadiusCorrection(const float value)
-    {
-        _updateValue(_radiusCorrection, value);
-    }
-    float getRadiusCorrection() const { return _radiusCorrection; }
-    /** Enables a different color for every molecule/morphology/mesh when
-     * loading them from a given folder
-     */
     ColorScheme getColorScheme() const { return _colorScheme; }
-    const std::string& getColorSchemeAsString(const ColorScheme value) const;
-    void setColorScheme(const ColorScheme value)
-    {
-        _updateValue(_colorScheme, value);
-    }
-
-    /** Morphology quality */
     GeometryQuality getGeometryQuality() const { return _geometryQuality; }
-    const std::string& getGeometryQualityAsString(
-        const GeometryQuality value) const;
-
-    /** Morphology section types*/
-    const MorphologySectionTypes& getMorphologySectionTypes() const
-    {
-        return _morphologySectionTypes;
-    }
-    /** Defines the range of frames to be loaded for the simulation */
-    double getCircuitEndSimulationTime() const
-    {
-        return _circuitConfiguration.endSimulationTime;
-    }
-    double getCircuitStartSimulationTime() const
-    {
-        return _circuitConfiguration.startSimulationTime;
-    }
-    double getCircuitSimulationStep() const
-    {
-        return _circuitConfiguration.simulationStep;
-    }
-    Vector2d getCircuitSimulationValuesRange() const
-    {
-        return _circuitConfiguration.simulationValuesRange;
-    }
-
-    bool getCircuitTransformMeshes() const
-    {
-        return _circuitConfiguration.transformMeshes;
-    }
-
-    /** Random seed of the circuit */
-    size_t getCircuitRandomSeed() const
-    {
-        return _circuitConfiguration.randomSeed;
-    }
+    float getRadiusMultiplier() const { return _radiusMultiplier; }
 
     /**
      * Defines what memory mode should be used between Brayns and the
      * underlying renderer
      */
     MemoryMode getMemoryMode() const { return _memoryMode; };
-    bool getMorphologyDampenBranchThicknessChangerate() const
-    {
-        return _morphologyDampenBranchThicknessChangerate;
-    }
-
-    bool getMorphologyUseSdfGeometries() const
-    {
-        return _morphologyUseSdfGeometries;
-    }
-
     const std::set<BVHFlag>& getDefaultBVHFlags() const
     {
         return _defaultBVHFlags;
@@ -197,25 +63,18 @@ public:
 protected:
     void parse(const po::variables_map& vm) final;
 
-    // Circuit
-    CircuitConfiguration _circuitConfiguration;
-
     // Scene
     std::string _loadCacheFile;
     std::string _saveCacheFile;
-
-    // Morphology
-    float _radiusMultiplier;
-    float _radiusCorrection;
-    ColorScheme _colorScheme;
-    GeometryQuality _geometryQuality;
     std::set<BVHFlag> _defaultBVHFlags;
-    MorphologySectionTypes _morphologySectionTypes;
-    bool _morphologyDampenBranchThicknessChangerate;
-    bool _morphologyUseSdfGeometries;
+
+    // Geometry
+    ColorScheme _colorScheme{ColorScheme::none};
+    GeometryQuality _geometryQuality{GeometryQuality::high};
+    float _radiusMultiplier{1};
 
     // System parameters
-    MemoryMode _memoryMode;
+    MemoryMode _memoryMode{MemoryMode::shared};
 
     SERIALIZATION_FRIEND(GeometryParameters)
 };

--- a/plugins/CircuitViewer/CircuitViewer.h
+++ b/plugins/CircuitViewer/CircuitViewer.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <brayns/common/PropertyMap.h>
 #include <brayns/common/types.h>
 #include <brayns/pluginapi/ExtensionPlugin.h>
 
@@ -28,6 +29,12 @@ namespace brayns
 class CircuitViewer : public ExtensionPlugin
 {
 public:
+    CircuitViewer(PropertyMap&& circuitParams, PropertyMap&& morphologyParams);
+
     void init() final;
+
+private:
+    PropertyMap _circuitParams;
+    PropertyMap _morphologyParams;
 };
 }

--- a/plugins/CircuitViewer/io/CircuitLoader.h
+++ b/plugins/CircuitViewer/io/CircuitLoader.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
+ * Responsible Author: Juan Hernando <juan.hernando@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -22,7 +22,6 @@
 
 #include <brayns/common/loader/Loader.h>
 #include <brayns/common/types.h>
-#include <brayns/parameters/GeometryParameters.h>
 
 #include <vector>
 
@@ -39,11 +38,12 @@ namespace brayns
 class CircuitLoader : public Loader
 {
 public:
-    CircuitLoader(Scene& scene);
+    CircuitLoader(Scene& scene, PropertyMap defaultParams);
     ~CircuitLoader();
 
     std::vector<std::string> getSupportedExtensions() const final;
     std::string getName() const final;
+    static PropertyMap getCLIProperties();
     PropertyMap getProperties() const final;
 
     bool isSupported(const std::string& filename,
@@ -60,5 +60,7 @@ public:
                                       const PropertyMap& properties,
                                       const size_t index,
                                       const size_t materialID) const final;
+private:
+    PropertyMap _defaults; // command line defaults
 };
 }

--- a/plugins/CircuitViewer/io/MorphologyLoader.h
+++ b/plugins/CircuitViewer/io/MorphologyLoader.h
@@ -23,13 +23,10 @@
 
 #include <brayns/common/loader/Loader.h>
 #include <brayns/common/types.h>
-#include <brayns/parameters/GeometryParameters.h>
 
 #include <brain/neuron/types.h>
 #include <brain/types.h>
 #include <brion/types.h>
-
-#include <servus/types.h>
 
 #include <vector>
 
@@ -38,15 +35,34 @@ namespace brayns
 class CircuitLoader;
 struct ModelData;
 
+enum class NeuronColorScheme
+{
+    none = 0,
+    by_id = 1,
+    by_type = 2,
+    by_segment_type = 3,
+    by_layer = 4,
+    by_mtype = 5,
+    by_etype = 6,
+    by_target = 7,
+};
+
+enum class NeuronDisplayMode
+{
+    soma = 0,
+    no_axon = 1,
+    full = 2,
+};
+
 struct MorphologyLoaderParams
 {
     MorphologyLoaderParams() = default;
     MorphologyLoaderParams(const PropertyMap& properties);
 
-    ColorScheme colorScheme = ColorScheme::none;
+    NeuronColorScheme colorScheme = NeuronColorScheme::none;
     double radiusMultiplier = 0.0;
     double radiusCorrection = 0.0;
-    std::vector<MorphologySectionType> sectionTypes;
+    NeuronDisplayMode mode;
     bool dampenBranchThicknessChangerate = false;
     bool useSDFGeometries = false;
     GeometryQuality geometryQuality = GeometryQuality::high;
@@ -58,11 +74,12 @@ struct MorphologyLoaderParams
 class MorphologyLoader : public Loader
 {
 public:
-    MorphologyLoader(Scene& scene);
+    MorphologyLoader(Scene& scene, PropertyMap defaultParams);
     ~MorphologyLoader();
 
-    std::vector<std::string> getSupportedExtensions() const final;
+    strings getSupportedExtensions() const final;
     std::string getName() const final;
+    static PropertyMap getCLIProperties();
     PropertyMap getProperties() const final;
 
     bool isSupported(const std::string& filename,
@@ -81,15 +98,17 @@ public:
 
     using MaterialFunc = std::function<size_t(brain::neuron::SectionType)>;
 
-    ModelData processMorphology(
+    static ModelData processMorphology(
         const brain::neuron::Morphology& morphology, const uint64_t index,
         MaterialFunc materialFunc,
         const brain::CompartmentReportMapping* reportMapping,
-        const MorphologyLoaderParams& params) const;
+        const MorphologyLoaderParams& params);
 
 private:
     friend class CircuitLoader;
     class Impl;
+
+    PropertyMap _defaults; // command line defaults
 };
 }
 

--- a/plugins/CircuitViewer/io/SimulationHandler.cpp
+++ b/plugins/CircuitViewer/io/SimulationHandler.cpp
@@ -22,8 +22,6 @@
 
 #include <brayns/common/log.h>
 #include <brayns/common/material/Material.h>
-#include <brayns/parameters/ApplicationParameters.h>
-#include <brayns/parameters/GeometryParameters.h>
 
 #include <brain/compartmentReport.h>
 #include <brain/compartmentReportMapping.h>
@@ -32,31 +30,28 @@
 
 namespace brayns
 {
-SimulationHandler::SimulationHandler(
-    const CompartmentReportPtr& compartmentReport, const bool synchronousMode,
-    const double startTime, const double endTime, const double simulationStep)
-    : _compartmentReport(compartmentReport)
+SimulationHandler::SimulationHandler(const CompartmentReportPtr& report,
+                                     const bool synchronousMode)
+    : _compartmentReport(report)
     , _synchronousMode(synchronousMode)
 {
     // Load simulation information from compartment reports
-    const auto& metadata = compartmentReport->getReader().getMetaData();
-    _startTime = std::max(metadata.startTime, startTime);
-    _endTime = std::min(metadata.endTime, endTime);
-    _dt = std::max(metadata.timeStep, simulationStep);
+    const auto& metadata = report->getReader().getMetaData();
+    _startTime = metadata.startTime;
+    _endTime = metadata.endTime;
+    _dt = metadata.timeStep;
     _unit = metadata.timeUnit;
-    _frameSize = _compartmentReport->getMapping().getFrameSize();
-    _nbFrames = (_endTime - _startTime) / _dt;
+    _nbFrames = metadata.frameCount;
+    _frameSize = report->getMapping().getFrameSize();
+
 
     BRAYNS_INFO << "-----------------------------------------------------------"
                 << std::endl;
     BRAYNS_INFO << "Simulation information" << std::endl;
     BRAYNS_INFO << "----------------------" << std::endl;
-    BRAYNS_INFO << "Start frame          : " << _startTime << "/"
-                << metadata.startTime << std::endl;
-    BRAYNS_INFO << "End frame            : " << _endTime << "/"
-                << metadata.endTime << std::endl;
-    BRAYNS_INFO << "Steps between frames : " << _dt << "/" << metadata.timeStep
-                << std::endl;
+    BRAYNS_INFO << "Start time          : " << _startTime << std::endl;
+    BRAYNS_INFO << "End time            : " << _endTime << std::endl;
+    BRAYNS_INFO << "Steps between frames : " << _dt << std::endl;
     BRAYNS_INFO << "Number of frames : " << _nbFrames << std::endl;
     BRAYNS_INFO << "-----------------------------------------------------------"
                 << std::endl;

--- a/plugins/CircuitViewer/io/SimulationHandler.h
+++ b/plugins/CircuitViewer/io/SimulationHandler.h
@@ -40,15 +40,8 @@ using CompartmentReportPtr = std::shared_ptr<brain::CompartmentReportView>;
 class SimulationHandler : public AbstractSimulationHandler
 {
 public:
-    /**
-     * @brief Default constructor
-     * @param geometryParameters Geometry parameters
-     * @param reportSource path to report source
-     * @param gids GIDS to load
-     */
-    SimulationHandler(const CompartmentReportPtr& compartmentReport,
-                      const bool synchronousMode, const double startTime,
-                      const double endTime, const double simulationStep);
+    SimulationHandler(const CompartmentReportPtr& report,
+                      const bool synchronousMode);
     ~SimulationHandler();
 
     void bind(const MaterialPtr& material) final;

--- a/plugins/CircuitViewer/tests/addCircuit.cpp
+++ b/plugins/CircuitViewer/tests/addCircuit.cpp
@@ -33,7 +33,7 @@ const std::string ADD_MODEL("add-model");
 
 BOOST_AUTO_TEST_CASE(file_no_extension_blueconfig)
 {
-    ClientServer clientServer({"--plugin", "braynsCircuitViewer"});
+    ClientServer clientServer({"--plugin", "braynsCircuitViewer --density 1"});
 
     auto circuit = makeRequest<brayns::ModelParams, brayns::ModelDescriptor>(
         ADD_MODEL, {"circuit", BBP_TEST_BLUECONFIG});

--- a/plugins/CircuitViewer/tests/braynsTestData.cpp
+++ b/plugins/CircuitViewer/tests/braynsTestData.cpp
@@ -43,15 +43,10 @@ BOOST_AUTO_TEST_CASE(simple_circuit)
     auto& testSuite = boost::unit_test::framework::master_test_suite();
 
     const char* app = testSuite.argv[0];
-    const char* argv[] = {app,
-                          BBP_TEST_BLUECONFIG3,
-                          "--plugin",
-                          "braynsCircuitViewer",
-                          "--disable-accumulation",
-                          "--circuit-targets",
-                          "Layer1",
-                          "--samples-per-pixel",
-                          "16"};
+    const char* argv[] = {
+        app, BBP_TEST_BLUECONFIG3, "--disable-accumulation",
+        "--samples-per-pixel", "16", "--plugin",
+        "braynsCircuitViewer --targets Layer1"};
     const int argc = sizeof(argv) / sizeof(char*);
 
     brayns::Brayns brayns(argc, argv);
@@ -62,22 +57,19 @@ BOOST_AUTO_TEST_CASE(simple_circuit)
                                  brayns.getEngine().getFrameBuffer()));
 }
 
-BOOST_AUTO_TEST_CASE(curcuit_with_color_by_mtype)
+BOOST_AUTO_TEST_CASE(circuit_with_color_by_mtype)
 {
     auto& testSuite = boost::unit_test::framework::master_test_suite();
 
     const char* app = testSuite.argv[0];
-    const char* argv[] = {app,
-                          BBP_TEST_BLUECONFIG3,
-                          "--plugin",
-                          "braynsCircuitViewer",
-                          "--disable-accumulation",
-                          "--circuit-targets",
-                          "MiniColumn_0",
-                          "--samples-per-pixel",
-                          "16",
-                          "--color-scheme",
-                          "neuron-by-mtype"};
+    const char* argv[] = {
+        app,
+        BBP_TEST_BLUECONFIG3,
+        "--disable-accumulation",
+        "--samples-per-pixel",
+        "16",
+        "--plugin",
+        "braynsCircuitViewer --targets MiniColumn_0 --color-scheme by-mtype"};
     const int argc = sizeof(argv) / sizeof(char*);
 
     brayns::Brayns brayns(argc, argv);
@@ -95,19 +87,11 @@ BOOST_AUTO_TEST_CASE(circuit_with_simulation_mapping)
     auto& testSuite = boost::unit_test::framework::master_test_suite();
 
     const char* app = testSuite.argv[0];
-    const char* argv[] = {app,
-                          BBP_TEST_BLUECONFIG3,
-                          "--plugin",
-                          "braynsCircuitViewer",
-                          "--circuit-targets",
-                          "allmini50",
-                          "--circuit-report",
-                          "voltages",
-                          "--samples-per-pixel",
-                          "16",
-                          "--animation-frame",
-                          "50",
-                          "--synchronous-mode"};
+    const char* argv[] = {app, BBP_TEST_BLUECONFIG3, "--samples-per-pixel",
+                          "16", "--animation-frame", "50", "--plugin",
+                          "braynsCircuitViewer --targets allmini50 --report "
+                          "voltages --synchronous-mode"};
+
     const int argc = sizeof(argv) / sizeof(char*);
 
     brayns::Brayns brayns(argc, argv);
@@ -140,16 +124,17 @@ void testSdfGeometries(bool dampened)
     const char* app = testSuite.argv[0];
     auto argv = std::vector<const char*>{app,
                                          BBP_TEST_BLUECONFIG3,
-                                         "--plugin",
-                                         "braynsCircuitViewer",
                                          "--disable-accumulation",
-                                         "--circuit-targets",
-                                         "Layer1",
-                                         "--morphology-use-sdf-geometries",
                                          "--samples-per-pixel",
-                                         "16"};
+                                         "16",
+                                         "--plugin"};
     if (dampened)
-        argv.push_back("--morphology-dampen-branch-thickness-changerate");
+        argv.push_back(
+            "braynsCircuitViewer --targets Layer1 --use-sdf-geometries "
+            "--dampen-branch-thickness-changerate");
+    else
+        argv.push_back(
+            "braynsCircuitViewer --targets Layer1 --use-sdf-geometries");
 
     const int argc = argv.size();
 

--- a/plugins/Rockets/RocketsPlugin.cpp
+++ b/plugins/Rockets/RocketsPlugin.cpp
@@ -61,7 +61,6 @@ const std::string ENDPOINT_ANIMATION_PARAMS = "animation-parameters";
 const std::string ENDPOINT_APP_PARAMS = "application-parameters";
 const std::string ENDPOINT_CAMERA = "camera";
 const std::string ENDPOINT_CAMERA_PARAMS = "camera-params";
-const std::string ENDPOINT_GEOMETRY_PARAMS = "geometry-parameters";
 const std::string ENDPOINT_RENDERER = "renderer";
 const std::string ENDPOINT_RENDERER_PARAMS = "renderer-params";
 const std::string ENDPOINT_SCENE = "scene";
@@ -927,8 +926,6 @@ public:
         _handle(ENDPOINT_ANIMATION_PARAMS,
                 _parametersManager.getAnimationParameters(),
                 INTERACTIVE_THROTTLE);
-        _handle(ENDPOINT_GEOMETRY_PARAMS,
-                _parametersManager.getGeometryParameters());
         _handle(ENDPOINT_SCENE_PARAMS, _parametersManager.getSceneParameters());
         _handle(ENDPOINT_VOLUME_PARAMS,
                 _parametersManager.getVolumeParameters());

--- a/plugins/Rockets/jsonSerialization.h
+++ b/plugins/Rockets/jsonSerialization.h
@@ -34,7 +34,6 @@
 #include <brayns/common/utils/utils.h>
 #include <brayns/parameters/AnimationParameters.h>
 #include <brayns/parameters/ApplicationParameters.h>
-#include <brayns/parameters/GeometryParameters.h>
 #include <brayns/parameters/RenderingParameters.h>
 #include <brayns/parameters/SceneParameters.h>
 #include <brayns/parameters/VolumeParameters.h>
@@ -83,24 +82,9 @@ STATICJSON_DECLARE_ENUM(brayns::GeometryQuality,
                         {"medium", brayns::GeometryQuality::medium},
                         {"high", brayns::GeometryQuality::high});
 
-STATICJSON_DECLARE_ENUM(brayns::MorphologySectionType,
-                        {"soma", brayns::MorphologySectionType::soma},
-                        {"axon", brayns::MorphologySectionType::axon},
-                        {"dendrite", brayns::MorphologySectionType::dendrite},
-                        {"apical_dendrite",
-                         brayns::MorphologySectionType::apical_dendrite},
-                        {"all", brayns::MorphologySectionType::all});
-
 STATICJSON_DECLARE_ENUM(
     brayns::ColorScheme, {"none", brayns::ColorScheme::none},
-    {"neuron_by_id", brayns::ColorScheme::neuron_by_id},
-    {"neuron_by_type", brayns::ColorScheme::neuron_by_type},
-    {"neuron_by_segment_type", brayns::ColorScheme::neuron_by_segment_type},
-    {"neuron_by_layer", brayns::ColorScheme::neuron_by_layer},
-    {"neuron_by_mtype", brayns::ColorScheme::neuron_by_mtype},
-    {"neuron_by_etype", brayns::ColorScheme::neuron_by_etype},
-    {"neuron_by_target", brayns::ColorScheme::neuron_by_target},
-    {"protein_by_id", brayns::ColorScheme::protein_by_id},
+    {"by_id", brayns::ColorScheme::by_id},
     {"protein_atoms", brayns::ColorScheme::protein_atoms},
     {"protein_chains", brayns::ColorScheme::protein_chains},
     {"protein_residues", brayns::ColorScheme::protein_residues});
@@ -354,27 +338,6 @@ inline void init(brayns::Scene* s, ObjectHandler* h)
     h->set_flags(Flags::DisallowUnknownKey);
 }
 
-inline void init(brayns::CircuitConfiguration* c, ObjectHandler* h)
-{
-    h->add_property("density", &c->density, Flags::Optional);
-    h->add_property("mesh_filename_pattern", &c->meshFilenamePattern,
-                    Flags::Optional);
-    h->add_property("mesh_folder", &c->meshFolder, Flags::Optional);
-    h->add_property("transform_meshes", &c->transformMeshes, Flags::Optional);
-    h->add_property("use_simulation_model", &c->useSimulationModel,
-                    Flags::Optional);
-    h->add_property("targets", &c->targets, Flags::Optional);
-    h->add_property("report", &c->report, Flags::Optional);
-    h->add_property("start_simulation_time", &c->startSimulationTime,
-                    Flags::Optional);
-    h->add_property("end_simulation_time", &c->endSimulationTime,
-                    Flags::Optional);
-    h->add_property("simulation_step", &c->simulationStep, Flags::Optional);
-    h->add_property("simulation_values_range",
-                    toArray(c->simulationValuesRange), Flags::Optional);
-    h->set_flags(Flags::DisallowUnknownKey);
-}
-
 inline void init(brayns::ApplicationParameters* a, ObjectHandler* h)
 {
     h->add_property("engine", &a->_engine, Flags::IgnoreRead | Flags::Optional);
@@ -382,24 +345,6 @@ inline void init(brayns::ApplicationParameters* a, ObjectHandler* h)
     h->add_property("synchronous_mode", &a->_synchronousMode, Flags::Optional);
     h->add_property("image_stream_fps", &a->_imageStreamFPS, Flags::Optional);
     h->add_property("viewport", toArray(a->_windowSize), Flags::Optional);
-    h->set_flags(Flags::DisallowUnknownKey);
-}
-
-inline void init(brayns::GeometryParameters* g, ObjectHandler* h)
-{
-    h->add_property("load_cache_file", &g->_loadCacheFile, Flags::Optional);
-    h->add_property("save_cache_file", &g->_saveCacheFile, Flags::Optional);
-    h->add_property("radius_multiplier", &g->_radiusMultiplier,
-                    Flags::Optional);
-    h->add_property("radius_correction", &g->_radiusCorrection,
-                    Flags::Optional);
-    h->add_property("color_scheme", &g->_colorScheme, Flags::Optional);
-    h->add_property("geometry_quality", &g->_geometryQuality, Flags::Optional);
-    h->add_property("morphology_section_types", &g->_morphologySectionTypes,
-                    Flags::Optional);
-    h->add_property("memory_mode", &g->_memoryMode, Flags::Optional);
-    h->add_property("circuit_configuration", &g->_circuitConfiguration,
-                    Flags::Optional);
     h->set_flags(Flags::DisallowUnknownKey);
 }
 

--- a/tests/ClientServer.h
+++ b/tests/ClientServer.h
@@ -100,8 +100,7 @@ public:
         auto& testSuite = boost::unit_test::framework::master_test_suite();
         const char* app = testSuite.argv[0];
         std::vector<const char*> argv{
-            app, "demo", "--http-server", "localhost:0", "--circuit-density",
-            "1"};
+            app, "demo", "--http-server", "localhost:0"};
         for (const auto& arg : additionalArgv)
             argv.push_back(arg);
         const int argc = argv.size();

--- a/tests/brayns.cpp
+++ b/tests/brayns.cpp
@@ -82,24 +82,9 @@ BOOST_AUTO_TEST_CASE(defaults)
     const auto& geomParams = pm.getGeometryParameters();
     BOOST_CHECK_EQUAL(geomParams.getLoadCacheFile(), "");
     BOOST_CHECK_EQUAL(geomParams.getSaveCacheFile(), "");
-    BOOST_CHECK_EQUAL(geomParams.getCircuitTargets(), "");
-    BOOST_CHECK_EQUAL(geomParams.getCircuitReport(), "");
-    BOOST_CHECK_EQUAL(geomParams.getRadiusMultiplier(), 1.f);
-    BOOST_CHECK_EQUAL(geomParams.getRadiusCorrection(), 0.f);
     BOOST_CHECK(geomParams.getColorScheme() == brayns::ColorScheme::none);
     BOOST_CHECK(geomParams.getGeometryQuality() ==
                 brayns::GeometryQuality::high);
-    BOOST_CHECK_EQUAL(
-        brayns::enumsToBitmask(geomParams.getMorphologySectionTypes()),
-        brayns::enumsToBitmask(std::vector<brayns::MorphologySectionType>{
-            brayns::MorphologySectionType::all}));
-    BOOST_CHECK_EQUAL(geomParams.getCircuitStartSimulationTime(), 0.f);
-    BOOST_CHECK_EQUAL(geomParams.getCircuitEndSimulationTime(),
-                      std::numeric_limits<float>::max());
-    BOOST_CHECK_EQUAL(geomParams.getCircuitSimulationValuesRange().x(),
-                      std::numeric_limits<double>::max());
-    BOOST_CHECK_EQUAL(geomParams.getCircuitSimulationValuesRange().y(),
-                      std::numeric_limits<double>::min());
 
     const auto& animParams = pm.getAnimationParameters();
     BOOST_CHECK_EQUAL(animParams.getFrame(), 0);


### PR DESCRIPTION
Most ColorScheme values moved to a new plugin specific enum called
NeuronColorScheme.

Simplified load properties:
- Section bitmask becomes an enum for only soma, no axon and full cells
- Simulation start, end and step time removed

Removed GeometryParamaters entry point for the web interface.

MeshLoader interface simplified. ColorScheme and index parameters removed
from where it was possible in favour of a single parameter, which is the
default material id to use when the model doesn't provide its own materials.

No PropertyMap passed to loaders during _loadData anymore. The reason is
that the colorScheme from GeometryParameters overrides the CircuitViewer
plugin default.
Default parameters from CLI are now passed to builtin loaders at
registration time.