### PR TITLE
Fix Rockets deadlock in plugins

### DIFF
--- a/plugins/Rockets/RocketsPlugin.cpp
+++ b/plugins/Rockets/RocketsPlugin.cpp
@@ -290,9 +290,8 @@ public:
                          const PropertyMap& input, const PropertyMap& output,
                          const std::function<PropertyMap(PropertyMap)>& action)
     {
-        _bindEndpoint(desc.methodName, [ name = desc.methodName, action,
-                                         this ](const auto& request) {
-            ScopedCurrentClient scope(this->_currentClientID, request.clientID);
+        _bindEndpoint(desc.methodName, [ name = desc.methodName,
+                                         action ](const auto& request) {
             try
             {
                 return Response{


### PR DESCRIPTION
A deadlock can appear when doing scene modifications with callbacks to rockets in a plugin method that was initially called from rockets. Fixed by adding the proper scope guards.