### PR TITLE
Draw FPS in screen instead of window title

### DIFF
--- a/apps/BraynsViewer/BraynsViewer.cpp
+++ b/apps/BraynsViewer/BraynsViewer.cpp
@@ -39,19 +39,7 @@ void BraynsViewer::display()
     const auto& ap = _brayns.getParametersManager().getApplicationParameters();
     std::stringstream ss;
     ss << "Brayns Viewer [" << ap.getEngine() << "] ";
-    auto animationFrame =
-        _brayns.getParametersManager().getAnimationParameters().getFrame();
-    if (animationFrame != std::numeric_limits<uint32_t>::max())
-        ss << " (frame " << animationFrame << ")";
-    if (_brayns.getParametersManager()
-            .getApplicationParameters()
-            .isBenchmarking())
-    {
-        ss << " @ " << _timer.perSecondSmoothed() << " / "
-           << _brayns.getEngine().getStatistics().getFPS() << " FPS";
-    }
     setTitle(ss.str());
-
     BaseWindow::display();
 }
-}
+} // namespace brayns

--- a/apps/ui/BaseWindow.h
+++ b/apps/ui/BaseWindow.h
@@ -117,26 +117,23 @@ protected:
 
     Brayns& _brayns;
 
-    Vector2i _lastMousePos; /*! last mouse screen position of mouse before
-                                    current motion */
-    Vector2i _currMousePos; /*! current screen position of mouse */
-    Vector2i _mouse;
-    u_int64_t _lastButtonState;
-    u_int64_t _currButtonState;
-    u_int64_t _currModifiers;
+    Vector2i _lastMousePos{-1, -1}; /*! last mouse screen position of mouse
+                                     before current motion */
+    Vector2i _currMousePos{-1, -1}; /*! current screen position of mouse */
+    u_int64_t _lastButtonState{0};
+    u_int64_t _currButtonState{0};
+    u_int64_t _currModifiers{0};
 
     FrameBufferMode _frameBufferMode;
 
-    int _windowID;
-    Vector2ui _windowSize;
+    int _windowID{-1};
+    Vector2ui _windowSize{0, 0};
 
     Timer _timer;
 
-    uint64_t _gid;
-
-    bool _displayHelp;
-    bool _fullScreen;
-    Vector2ui _windowPosition;
+    bool _displayHelp{false};
+    bool _fullScreen{false};
+    Vector2ui _windowPosition{0, 0};
 
     GLuint _fbTexture{0};
 
@@ -157,6 +154,6 @@ private:
     friend void glut3dMouseFunc(int whichButton, int released, int x, int y);
     friend void glut3dPassiveMouseFunc(int x, int y);
 };
-}
+} // namespace brayns
 
 #endif

--- a/brayns/common/input/KeyboardHandler.cpp
+++ b/brayns/common/input/KeyboardHandler.cpp
@@ -28,10 +28,6 @@
 
 namespace brayns
 {
-KeyboardHandler::KeyboardHandler()
-{
-}
-
 void KeyboardHandler::registerKeyboardShortcut(const unsigned char key,
                                                const std::string& description,
                                                std::function<void()> functor)
@@ -47,6 +43,7 @@ void KeyboardHandler::registerKeyboardShortcut(const unsigned char key,
         ShortcutInformation shortcutInformation = {description, functor};
         _registeredShortcuts[key] = shortcutInformation;
     }
+    _buildHelp();
 }
 
 void KeyboardHandler::unregisterKeyboardShortcut(const unsigned char key)
@@ -54,6 +51,7 @@ void KeyboardHandler::unregisterKeyboardShortcut(const unsigned char key)
     auto it = _registeredShortcuts.find(key);
     if (it != _registeredShortcuts.end())
         _registeredShortcuts.erase(it);
+    _buildHelp();
 }
 
 void KeyboardHandler::handleKeyboardShortcut(const unsigned char key)
@@ -81,6 +79,7 @@ void KeyboardHandler::registerSpecialKey(const SpecialKey key,
         ShortcutInformation shortcutInformation = {description, functor};
         _registeredSpecialKeys[key] = shortcutInformation;
     }
+    _buildHelp();
 }
 
 void KeyboardHandler::unregisterSpecialKey(const SpecialKey key)
@@ -88,6 +87,7 @@ void KeyboardHandler::unregisterSpecialKey(const SpecialKey key)
     auto it = _registeredSpecialKeys.find(key);
     if (it != _registeredSpecialKeys.end())
         _registeredSpecialKeys.erase(it);
+    _buildHelp();
 }
 
 void KeyboardHandler::handle(const SpecialKey key)
@@ -100,16 +100,46 @@ void KeyboardHandler::handle(const SpecialKey key)
     }
 }
 
-std::string KeyboardHandler::help()
+void KeyboardHandler::_buildHelp()
 {
-    std::stringstream result;
-    result << "Keyboard shortcuts:" << std::endl;
+    _helpStrings.clear();
+    _helpStrings.push_back("Keyboard shortcuts:");
+
+    const auto specialKeyToString = [](const SpecialKey key) {
+        switch (key)
+        {
+        case SpecialKey::RIGHT:
+            return "Right";
+        case SpecialKey::UP:
+            return "Up";
+        case SpecialKey::DOWN:
+            return "Down";
+        case SpecialKey::LEFT:
+            return "Left";
+        };
+
+        return "INVALID";
+    };
+
     for (const auto& registeredShortcut : _registeredShortcuts)
-        result << "'" << registeredShortcut.first
-               << "' " + registeredShortcut.second.description << "\n";
+    {
+        std::stringstream ss;
+        ss << "'" << registeredShortcut.first << "' "
+           << registeredShortcut.second.description;
+        _helpStrings.push_back(ss.str());
+    }
     for (const auto& registeredShortcut : _registeredSpecialKeys)
-        result << "'" << (int)registeredShortcut.first
-               << "' " + registeredShortcut.second.description << "\n";
-    return result.str();
+    {
+        std::stringstream ss;
+        ss << "'" << specialKeyToString(registeredShortcut.first) << "' "
+           << registeredShortcut.second.description;
+        _helpStrings.push_back(ss.str());
+    }
+
+} // namespace brayns
+
+const std::vector<std::string>& KeyboardHandler::help() const
+{
+    return _helpStrings;
 }
-}
+} // namespace brayns

--- a/brayns/common/input/KeyboardHandler.h
+++ b/brayns/common/input/KeyboardHandler.h
@@ -44,8 +44,6 @@ enum class SpecialKey
 class KeyboardHandler
 {
 public:
-    KeyboardHandler();
-
     void registerKeyboardShortcut(const unsigned char key,
                                   const std::string& description,
                                   std::function<void()> functor);
@@ -62,12 +60,15 @@ public:
 
     void handle(const SpecialKey key);
 
-    std::string help();
+    const std::vector<std::string>& help() const;
 
 private:
+    void _buildHelp();
+
     std::map<unsigned char, ShortcutInformation> _registeredShortcuts;
     std::map<SpecialKey, ShortcutInformation> _registeredSpecialKeys;
+    std::vector<std::string> _helpStrings;
 };
-}
+} // namespace brayns
 
 #endif // KEYBOARDHANDLER_H

--- a/brayns/common/utils/utils.cpp
+++ b/brayns/common/utils/utils.cpp
@@ -136,4 +136,18 @@ bool containsString(const int length, const char** input, const char* toFind)
                return std::strcmp(arg, toFind) == 0;
            }) > 0;
 }
+
+std::string joinStrings(const std::vector<std::string>& strings,
+                        const std::string& joinWith)
+{
+    const size_t numStrings = strings.size();
+    if (numStrings == 0)
+        return "";
+
+    std::stringstream ss;
+    ss << strings[0];
+    for (size_t i = 1; i < numStrings; i++)
+        ss << joinWith << strings[i];
+    return ss.str();
 }
+} // namespace brayns

--- a/brayns/common/utils/utils.h
+++ b/brayns/common/utils/utils.h
@@ -63,4 +63,6 @@ std::string camelCaseToSeparated(const std::string& camelCase,
                                  const char separator);
 std::string separatedToCamelCase(const std::string& separated,
                                  const char separator);
-}
+std::string joinStrings(const std::vector<std::string>& strings,
+                        const std::string& joinWith);
+} // namespace brayns


### PR DESCRIPTION
This avoids lag in Unity due to too many window updates per second and is more readable.