### PR TITLE
bug(optix): fix snapshot crash in OptiX

### DIFF
--- a/apps/ui/Application.cpp
+++ b/apps/ui/Application.cpp
@@ -388,6 +388,8 @@ void Application::render()
     glClearColor(0.f, 0.f, 0.f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+    auto lock{m_brayns.getEngine().getRenderScopeLock()};
+
     size_t offset = 0;
     size_t bufferIdx = 0;
     for (auto frameBuffer : m_brayns.getEngine().getFrameBuffers())

--- a/brayns/engine/Engine.cpp
+++ b/brayns/engine/Engine.cpp
@@ -70,11 +70,6 @@ void Engine::postRender()
         frameBuffer->incrementAccumFrames();
 }
 
-Renderer& Engine::getRenderer()
-{
-    return *_renderer;
-}
-
 bool Engine::continueRendering() const
 {
     auto frameBuffer = _frameBuffers[0];

--- a/engines/optix/OptiXEngine.h
+++ b/engines/optix/OptiXEngine.h
@@ -51,6 +51,7 @@ public:
         const AnimationParameters& animationParameters,
         const RenderingParameters& renderingParameters) const final;
 
+    bool supportsConcurrentSnapshots() const final { return false; }
 private:
     void _initializeContext();
     void _createRenderers();

--- a/engines/ospray/OSPRayEngine.h
+++ b/engines/ospray/OSPRayEngine.h
@@ -52,7 +52,7 @@ public:
     RendererPtr createRenderer(
         const AnimationParameters& animationParameters,
         const RenderingParameters& renderingParameters) const final;
-
+    bool supportsConcurrentSnapshots() const final { return true; }
 private:
     void _createCameras();
     void _createRenderers();

--- a/plugins/Rockets/CMakeLists.txt
+++ b/plugins/Rockets/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BRAYNSROCKETS_HEADERS
 set(BRAYNSROCKETS_SOURCES
   ImageGenerator.cpp
   RocketsPlugin.cpp
+  SnapshotTask.cpp
   Throttle.cpp
   Timeout.cpp
   staticjson/staticjson.cpp

--- a/plugins/Rockets/SnapshotTask.cpp
+++ b/plugins/Rockets/SnapshotTask.cpp
@@ -1,0 +1,188 @@
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ *
+ * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <brayns/common/tasks/Task.h>
+
+#include "ImageGenerator.h"
+#include <brayns/common/utils/utils.h>
+#include <brayns/engine/Camera.h>
+#include <brayns/engine/Engine.h>
+#include <brayns/engine/FrameBuffer.h>
+#include <brayns/engine/Renderer.h>
+#include <brayns/engine/Scene.h>
+
+#include <brayns/parameters/ParametersManager.h>
+
+#include "SnapshotTask.h"
+
+namespace brayns
+{
+SnapshotFunctor::SnapshotFunctor(Engine &engine, SnapshotParams &&params,
+                                 ImageGenerator &imageGenerator)
+    : _params(std::move(params))
+    , _imageGenerator(imageGenerator)
+    , _engine(engine)
+{
+    if (_params.animParams == nullptr)
+    {
+        _params.animParams = std::make_unique<AnimationParameters>(
+            engine.getParametersManager().getAnimationParameters());
+    }
+
+    if (_params.geometryParams == nullptr)
+    {
+        _params.geometryParams = std::make_unique<GeometryParameters>(
+            engine.getParametersManager().getGeometryParameters());
+    }
+
+    if (_params.renderingParams == nullptr)
+    {
+        _params.renderingParams = std::make_unique<RenderingParameters>(
+            engine.getParametersManager().getRenderingParameters());
+    }
+
+    if (_params.volumeParams == nullptr)
+    {
+        _params.volumeParams = std::make_unique<VolumeParameters>(
+            engine.getParametersManager().getVolumeParameters());
+    }
+
+    if (_engine.supportsConcurrentSnapshots())
+    {
+        _camera = engine.createCamera();
+        _scene =
+            engine.createScene(*_params.animParams, *_params.geometryParams,
+                               *_params.volumeParams);
+
+        _renderer = engine.createRenderer(*_params.animParams,
+                                          *_params.renderingParams);
+
+        const auto &renderer = engine.getRenderer();
+        _renderer->setCurrentType(renderer.getCurrentType());
+        _renderer->clonePropertiesFrom(renderer);
+        if (_params.camera)
+        {
+            *_camera = *_params.camera;
+            _camera->setCurrentType(engine.getCamera().getCurrentType());
+            _camera->clonePropertiesFrom(engine.getCamera());
+        }
+        else
+            *_camera = engine.getCamera();
+
+        _scene->copyFrom(engine.getScene());
+    }
+    else
+    {
+        _camera = engine.getCameraPtr();
+        _renderer = engine.getRendererPtr();
+    }
+}
+
+ImageGenerator::ImageBase64 SnapshotFunctor::_renderSnapshot(
+    const size_t numAccumulations)
+{
+    const auto nameShort =
+        _params.name.empty() ? "" : " " + shortenString(_params.name);
+    const auto msg = "Render snapshot" + nameShort + "...";
+
+    const auto isStereo =
+        _camera->hasProperty("stereo") && _camera->getProperty<bool>("stereo");
+    const auto names = isStereo ? strings{"0L", "0R"} : strings{"default"};
+
+    std::vector<FrameBufferPtr> frameBuffers;
+    for (const auto &name : names)
+    {
+        frameBuffers.push_back(
+            _engine.createFrameBuffer(name, _params.size,
+                                      FrameBufferFormat::rgba_i8));
+    }
+
+    for (size_t i = 0; i < numAccumulations; i++)
+    {
+        for (auto &frameBuffer : frameBuffers)
+        {
+            _camera->setBufferTarget(frameBuffer->getName());
+            _camera->markModified(false);
+            _camera->commit();
+            _camera->resetModified();
+            _renderer->render(frameBuffer);
+            frameBuffer->incrementAccumFrames();
+        }
+
+        progress(msg, 1.f / numAccumulations,
+                 static_cast<float>(i) / numAccumulations);
+    }
+
+    return _imageGenerator.createImage(frameBuffers, _params.format,
+                                       _params.quality);
+}
+
+ImageGenerator::ImageBase64 SnapshotFunctor::_takeSnapshotConcurrent()
+{
+    _scene->commit();
+
+    _camera->updateProperty("aspect", double(_params.size.x) / _params.size.y);
+    _camera->commit();
+
+    if (_params.renderingParams)
+    {
+        _params.renderingParams->setSamplesPerPixel(1);
+        _params.renderingParams->setSubsampling(1);
+    }
+
+    _scene->commitLights();
+
+    _renderer->setCamera(_camera);
+    _renderer->setScene(_scene);
+    _renderer->commit();
+
+    return _renderSnapshot(_params.samplesPerPixel);
+}
+
+ImageGenerator::ImageBase64 SnapshotFunctor::_takeSnapshotSerial()
+{
+    auto lock{_engine.getRenderScopeLock()};
+
+    auto &renderingParameters =
+        _engine.getParametersManager().getRenderingParameters();
+    auto &renderer = _engine.getRenderer();
+
+    const auto aspectPrev = _camera->getProperty<double>("aspect");
+    const auto sppPrev = renderingParameters.getSamplesPerPixel();
+
+    _camera->updateProperty("aspect", double(_params.size.x) / _params.size.y);
+    renderingParameters.setSamplesPerPixel(_params.samplesPerPixel);
+    renderer.commit();
+
+    // Only render one frame to avoid ghosting if camera is moved or simulation
+    // frame changes between accumulation frames.
+    auto image = _renderSnapshot(1);
+
+    renderingParameters.setSamplesPerPixel(sppPrev);
+    _camera->updateProperty("aspect", aspectPrev);
+
+    return image;
+}
+
+ImageGenerator::ImageBase64 SnapshotFunctor::operator()()
+{
+    return _engine.supportsConcurrentSnapshots() ? _takeSnapshotConcurrent()
+                                                 : _takeSnapshotSerial();
+}
+} // namespace brayns

--- a/plugins/Rockets/SnapshotTask.h
+++ b/plugins/Rockets/SnapshotTask.h
@@ -56,114 +56,15 @@ class SnapshotFunctor : public TaskFunctor
 {
 public:
     SnapshotFunctor(Engine& engine, SnapshotParams&& params,
-                    ImageGenerator& imageGenerator)
-        : _params(std::move(params))
-        , _camera(engine.createCamera())
-        , _imageGenerator(imageGenerator)
-        , _engine(engine)
-    {
-        if (_params.animParams == nullptr)
-        {
-            _params.animParams = std::make_unique<AnimationParameters>(
-                engine.getParametersManager().getAnimationParameters());
-        }
+                    ImageGenerator& imageGenerator);
 
-        if (_params.geometryParams == nullptr)
-        {
-            _params.geometryParams = std::make_unique<GeometryParameters>(
-                engine.getParametersManager().getGeometryParameters());
-        }
-
-        if (_params.renderingParams == nullptr)
-        {
-            _params.renderingParams = std::make_unique<RenderingParameters>(
-                engine.getParametersManager().getRenderingParameters());
-        }
-
-        if (_params.volumeParams == nullptr)
-        {
-            _params.volumeParams = std::make_unique<VolumeParameters>(
-                engine.getParametersManager().getVolumeParameters());
-        }
-
-        _scene =
-            engine.createScene(*_params.animParams, *_params.geometryParams,
-                               *_params.volumeParams);
-
-        _renderer = engine.createRenderer(*_params.animParams,
-                                          *_params.renderingParams);
-
-        const auto& renderer = engine.getRenderer();
-        _renderer->setCurrentType(renderer.getCurrentType());
-        _renderer->clonePropertiesFrom(renderer);
-        if (_params.camera)
-        {
-            *_camera = *_params.camera;
-            _camera->setCurrentType(engine.getCamera().getCurrentType());
-            _camera->clonePropertiesFrom(engine.getCamera());
-        }
-        else
-            *_camera = engine.getCamera();
-
-        _scene->copyFrom(engine.getScene());
-    }
-
-    ImageGenerator::ImageBase64 operator()()
-    {
-        _scene->commit();
-
-        _camera->updateProperty("aspect",
-                                double(_params.size.x) / _params.size.y);
-        _camera->commit();
-
-        if (_params.renderingParams)
-        {
-            _params.renderingParams->setSamplesPerPixel(1);
-            _params.renderingParams->setSubsampling(1);
-        }
-
-        _renderer->setCamera(_camera);
-        _renderer->setScene(_scene);
-        _renderer->commit();
-
-        std::stringstream msg;
-        msg << "Render snapshot";
-        if (!_params.name.empty())
-            msg << " " << shortenString(_params.name);
-        msg << " ...";
-
-        const auto isStereo = _camera->hasProperty("stereo") &&
-                              _camera->getProperty<bool>("stereo");
-        const auto names = isStereo ? strings{"0L", "0R"} : strings{"default"};
-        std::vector<FrameBufferPtr> frameBuffers;
-        for (const auto& name : names)
-            frameBuffers.push_back(
-                _engine.createFrameBuffer(name, _params.size,
-                                          FrameBufferFormat::rgba_i8));
-
-        while (frameBuffers[0]->numAccumFrames() !=
-               size_t(_params.samplesPerPixel))
-        {
-            for (auto frameBuffer : frameBuffers)
-            {
-                _camera->setBufferTarget(frameBuffer->getName());
-                _camera->markModified(false);
-                _camera->commit();
-                _camera->resetModified();
-                _renderer->render(frameBuffer);
-                frameBuffer->incrementAccumFrames();
-            }
-
-            progress(msg.str(), 1.f / frameBuffers[0]->numAccumFrames(),
-                     float(frameBuffers[0]->numAccumFrames()) /
-                         _params.samplesPerPixel);
-        }
-
-        return _imageGenerator.createImage(frameBuffers, _params.format,
-                                           _params.quality);
-    }
+    ImageGenerator::ImageBase64 operator()();
 
 private:
+    ImageGenerator::ImageBase64 _takeSnapshotConcurrent();
+    ImageGenerator::ImageBase64 _takeSnapshotSerial();
+    ImageGenerator::ImageBase64 _renderSnapshot(const size_t numAccumulations);
+
     SnapshotParams _params;
     FrameBufferPtr _frameBuffer;
     CameraPtr _camera;


### PR DESCRIPTION
OptiX only supports one context per process so instead of cloning the scene and camera, the OptiX screenshots are rendered serially and reuses the same context.