### PR TITLE
Handle unexpected Deflect server disconnections gracefully

### DIFF
--- a/plugins/Deflect/DeflectPlugin.cpp
+++ b/plugins/Deflect/DeflectPlugin.cpp
@@ -175,6 +175,8 @@ private:
     void _setupSocketListener()
     {
 #ifdef BRAYNS_USE_LIBUV
+        assert(_stream->isConnected());
+
         auto loop = uvw::Loop::getDefault();
         _pollHandle = loop->resource<uvw::PollHandle>(_stream->getDescriptor());
 
@@ -184,6 +186,11 @@ private:
         });
 
         _pollHandle->start(uvw::PollHandle::Event::READABLE);
+
+        _stream->setDisconnectedCallback([&] {
+            _pollHandle->stop();
+            _pollHandle.reset();
+        });
 #endif
     }
 


### PR DESCRIPTION
This commit combined with 038e139 in Deflect master prevent an
abort within libuv when the socket fd gets closed by QTcpSocket
after a server side disconnect.