### PR TITLE
Support fixed number of tokens for program options

### DIFF
--- a/brayns/common/PropertyMap.cpp
+++ b/brayns/common/PropertyMap.cpp
@@ -1,6 +1,4 @@
-/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
- *
- * Responsible Author: Jonas Karlsson <jonas.karlsson@epfl.ch>
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -29,7 +27,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>
-namespace po = boost::program_options;
+#include <brayns/parameters/AbstractParameters.h>
 
 namespace brayns
 {
@@ -89,13 +87,19 @@ po::options_description _toCommandlineDescription(
                 valueSemantic = po::bool_switch();
             break;
         case Property::Type::Vec2i:
+            valueSemantic = po::fixed_tokens_value<ints>(2, 2);
+            break;
         case Property::Type::Vec3i:
-            valueSemantic = po::value<std::vector<int32_t>>()->multitoken();
+            valueSemantic = po::fixed_tokens_value<ints>(3, 3);
             break;
         case Property::Type::Vec2d:
+            valueSemantic = po::fixed_tokens_value<std::vector<double>>(2, 2);
+            break;
         case Property::Type::Vec3d:
+            valueSemantic = po::fixed_tokens_value<std::vector<double>>(3, 3);
+            break;
         case Property::Type::Vec4d:
-            valueSemantic = po::value<std::vector<double>>()->multitoken();
+            valueSemantic = po::fixed_tokens_value<std::vector<double>>(4, 4);
             break;
         }
 

--- a/brayns/parameters/AbstractParameters.h
+++ b/brayns/parameters/AbstractParameters.h
@@ -1,6 +1,5 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -18,14 +17,15 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef ABSTRACTPARAMETERS_H
-#define ABSTRACTPARAMETERS_H
+#pragma once
 
 #include <brayns/common/BaseObject.h>
 #include <brayns/common/log.h>
 #include <brayns/common/types.h>
 
 #include <boost/program_options.hpp>
+#include <boost/program_options/value_semantic.hpp>
+
 namespace po = boost::program_options;
 
 namespace brayns
@@ -67,4 +67,46 @@ protected:
     static std::string asString(const bool flag) { return flag ? "on" : "off"; }
 };
 }
-#endif // ABSTRACTPARAMETERS_H
+
+namespace boost
+{
+namespace program_options
+{
+/**
+ * Wrapper for supporting fixed size multitoken values
+ */
+template <typename T, typename charT = char>
+class fixed_tokens_typed_value : public typed_value<T, charT>
+{
+    const unsigned _min;
+    const unsigned _max;
+
+    typedef typed_value<T, charT> base;
+
+public:
+    fixed_tokens_typed_value(T* t, unsigned min, unsigned max)
+        : base(t)
+        , _min(min)
+        , _max(max)
+    {
+        base::multitoken();
+    }
+    unsigned min_tokens() const { return _min; }
+    unsigned max_tokens() const { return _max; }
+};
+
+template <typename T>
+inline fixed_tokens_typed_value<T>* fixed_tokens_value(unsigned min,
+                                                       unsigned max)
+{
+    return new fixed_tokens_typed_value<T>(nullptr, min, max);
+}
+
+template <typename T>
+inline fixed_tokens_typed_value<T>* fixed_tokens_value(T* t, unsigned min,
+                                                       unsigned max)
+{
+    return new fixed_tokens_typed_value<T>(t, min, max);
+}
+}
+}

--- a/brayns/parameters/ApplicationParameters.cpp
+++ b/brayns/parameters/ApplicationParameters.cpp
@@ -1,6 +1,5 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -30,7 +29,6 @@ const std::string PARAM_HTTP_SERVER = "http-server";
 const std::string PARAM_IMAGE_STREAM_FPS = "image-stream-fps";
 const std::string PARAM_INPUT_PATHS = "input-paths";
 const std::string PARAM_JPEG_COMPRESSION = "jpeg-compression";
-const std::string PARAM_JPEG_SIZE = "jpeg-size";
 const std::string PARAM_MAX_RENDER_FPS = "max-render-fps";
 const std::string PARAM_MODULE = "module";
 const std::string PARAM_PARALLEL_RENDERING = "parallel-rendering";
@@ -64,15 +62,13 @@ ApplicationParameters::ApplicationParameters()
          "can be repeated to load multiple plugins. "
          "Arguments to plugins can be added by inserting a space followed by "
          "the arguments like: --plugin 'myPluginName arg0 arg1'") //
-        (PARAM_WINDOW_SIZE.c_str(), po::value<uints>()->multitoken(),
-         "Window size [int int]") //
+        (PARAM_WINDOW_SIZE.c_str(), po::fixed_tokens_value<uints>(2, 2),
+         "Window size [uint uint]") //
         (PARAM_BENCHMARKING.c_str(),
          po::bool_switch(&_benchmarking)->default_value(false),
          "Enable benchmarking") //
         (PARAM_JPEG_COMPRESSION.c_str(), po::value<size_t>(&_jpegCompression),
          "JPEG compression rate (100 is full quality) [int]") //
-        (PARAM_JPEG_SIZE.c_str(), po::value<uints>()->multitoken(),
-         "JPEG size [int int]") //
         (PARAM_PARALLEL_RENDERING.c_str(),
          po::bool_switch(&_parallelRendering)->default_value(false),
          "Enable parallel rendering, equivalent to --osp:mpi") //
@@ -91,11 +87,8 @@ void ApplicationParameters::parse(const po::variables_map& vm)
     if (vm.count(PARAM_WINDOW_SIZE))
     {
         uints values = vm[PARAM_WINDOW_SIZE].as<uints>();
-        if (values.size() == 2)
-        {
-            _windowSize.x = values[0];
-            _windowSize.y = values[1];
-        }
+        _windowSize.x = values[0];
+        _windowSize.y = values[1];
     }
     markModified();
 }

--- a/brayns/parameters/RenderingParameters.cpp
+++ b/brayns/parameters/RenderingParameters.cpp
@@ -1,6 +1,5 @@
-/* Copyright (c) 2015-2018, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -48,7 +47,7 @@ RenderingParameters::RenderingParameters()
          "Subsampling factor [uint]") //
         (PARAM_ACCUMULATION.c_str(), po::bool_switch()->default_value(false),
          "Disable accumulation") //
-        (PARAM_BACKGROUND_COLOR.c_str(), po::value<floats>()->multitoken(),
+        (PARAM_BACKGROUND_COLOR.c_str(), po::fixed_tokens_value<floats>(3, 3),
          "Background color [float float float]") //
         (PARAM_CAMERA.c_str(), po::value<std::string>(),
          "The camera to use") //
@@ -76,8 +75,7 @@ void RenderingParameters::parse(const po::variables_map& vm)
     if (vm.count(PARAM_BACKGROUND_COLOR))
     {
         floats values = vm[PARAM_BACKGROUND_COLOR].as<floats>();
-        if (values.size() == 3)
-            _backgroundColor = Vector3f(values[0], values[1], values[2]);
+        _backgroundColor = Vector3f(values[0], values[1], values[2]);
     }
     if (vm.count(PARAM_CAMERA))
     {

--- a/brayns/parameters/VolumeParameters.cpp
+++ b/brayns/parameters/VolumeParameters.cpp
@@ -1,6 +1,5 @@
-/* Copyright (c) 2015-2016, EPFL/Blue Brain Project
+/* Copyright (c) 2015-2019, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Cyrille Favreau <cyrille.favreau@epfl.ch>
  *
  * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
  *
@@ -36,33 +35,31 @@ VolumeParameters::VolumeParameters()
     , _offset(0.f, 0.f, 0.f)
 {
     _parameters.add_options()(PARAM_VOLUME_DIMENSIONS.c_str(),
-                              po::value<size_ts>()->multitoken(),
-                              "Volume dimensions [int int int]")(
-        PARAM_VOLUME_ELEMENT_SPACING.c_str(), po::value<floats>()->multitoken(),
-        "Element spacing in the volume [int int int]")(
-        PARAM_VOLUME_OFFSET.c_str(), po::value<floats>()->multitoken(),
-        "Volume offset [int int int]");
+                              po::fixed_tokens_value<uints>(3, 3),
+                              "Volume dimensions [uint uint uint]")(
+        PARAM_VOLUME_ELEMENT_SPACING.c_str(),
+        po::fixed_tokens_value<floats>(3, 3),
+        "Element spacing in the volume [float float float]")(
+        PARAM_VOLUME_OFFSET.c_str(), po::fixed_tokens_value<floats>(3, 3),
+        "Volume offset [float float float]");
 }
 
 void VolumeParameters::parse(const po::variables_map& vm)
 {
     if (vm.count(PARAM_VOLUME_DIMENSIONS))
     {
-        size_ts values = vm[PARAM_VOLUME_DIMENSIONS].as<size_ts>();
-        if (values.size() == 3)
-            _dimensions = Vector3ui(values[0], values[1], values[2]);
+        auto values = vm[PARAM_VOLUME_DIMENSIONS].as<uints>();
+        _dimensions = Vector3ui(values[0], values[1], values[2]);
     }
     if (vm.count(PARAM_VOLUME_ELEMENT_SPACING))
     {
-        floats values = vm[PARAM_VOLUME_ELEMENT_SPACING].as<floats>();
-        if (values.size() == 3)
-            _elementSpacing = Vector3f(values[0], values[1], values[2]);
+        auto values = vm[PARAM_VOLUME_ELEMENT_SPACING].as<floats>();
+        _elementSpacing = Vector3f(values[0], values[1], values[2]);
     }
     if (vm.count(PARAM_VOLUME_OFFSET))
     {
-        floats values = vm[PARAM_VOLUME_OFFSET].as<floats>();
-        if (values.size() == 3)
-            _offset = Vector3f(values[0], values[1], values[2]);
+        auto values = vm[PARAM_VOLUME_OFFSET].as<floats>();
+        _offset = Vector3f(values[0], values[1], values[2]);
     }
     markModified();
 }

--- a/tests/propertyMap.cpp
+++ b/tests/propertyMap.cpp
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(commandline_too_many_vector_values)
     const char* argv[] = {app, "--vec2i", "3", "4", "5"};
     const int argc = sizeof(argv) / sizeof(char*);
 
-    BOOST_CHECK(!properties.parse(argc, argv));
+    BOOST_CHECK(properties.parse(argc, argv));
 }
 
 BOOST_AUTO_TEST_CASE(commandline_wrong_enum_value)


### PR DESCRIPTION
This forces options to have the correct number of values since it otherwise will fail parsing. It also allows using for instance "--window-size 100 100 demo".