### PR TITLE
Disable OSPRay pathtracer

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -67,7 +67,6 @@ Four renderers are currently supported:
 | basic_simulation    | Enhances ```basic``` with transparency and simulation rendering
 | advanced_simulation | Enhances ```basic_simulation``` with reflection, refraction, volume rendering, shadows and ambient occlusion
 | proximity           | Displays information about element proximity in 3D space. Typically used to find touches between neurons.
-| pathtracing         | Path tracing renderer
 | scivis              | Scientific visualization example renderer provided by OSPRay
 
 

--- a/engines/ospray/OSPRayEngine.cpp
+++ b/engines/ospray/OSPRayEngine.cpp
@@ -148,14 +148,6 @@ void OSPRayEngine::_createRenderers()
 
     {
         PropertyMap properties;
-        properties.setProperty({"shadows", 0., 0., 1., {"Shadow intensity"}});
-        properties.setProperty(
-            {"softShadows", 0., 0., 1., {"Shadow softness"}});
-        addRendererType("pathtracing", properties);
-    }
-
-    {
-        PropertyMap properties;
         properties.setProperty(
             {"alphaCorrection", 0.5, 0.001, 1., {"Alpha correction"}});
         properties.setProperty(

--- a/engines/ospray/ispc/render/DefaultMaterial.cpp
+++ b/engines/ospray/ispc/render/DefaultMaterial.cpp
@@ -97,7 +97,6 @@ void DefaultMaterial::commit()
 
 OSP_REGISTER_MATERIAL(basic, DefaultMaterial, default_material);
 OSP_REGISTER_MATERIAL(BASIC, DefaultMaterial, default_material);
-OSP_REGISTER_MATERIAL(pathtracing, DefaultMaterial, default_material);
 OSP_REGISTER_MATERIAL(proximity, DefaultMaterial, default_material);
 
 } // ::brayns

--- a/tests/brayns.cpp
+++ b/tests/brayns.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(defaults)
     BOOST_CHECK_EQUAL(renderParams.getCurrentCamera(), "perspective");
     BOOST_CHECK_EQUAL(renderParams.getCurrentRenderer(), "basic");
     BOOST_CHECK_EQUAL(renderParams.getCameras().size(), 4);
-    BOOST_CHECK_EQUAL(renderParams.getRenderers().size(), 6);
+    BOOST_CHECK_EQUAL(renderParams.getRenderers().size(), 5);
     BOOST_CHECK_EQUAL(renderParams.getSamplesPerPixel(), 1);
     BOOST_CHECK_EQUAL(renderParams.getBackgroundColor(),
                       brayns::Vector3d(0, 0, 0));


### PR DESCRIPTION
It never actually worked since it needs the Principled material. So we disable it until we can handle this material.