### PR TITLE
Treat OSPRay bool parameters as ints

### DIFF
--- a/engines/ospray/OSPRayCamera.cpp
+++ b/engines/ospray/OSPRayCamera.cpp
@@ -71,7 +71,7 @@ void OSPRayCamera::commit()
 
 void OSPRayCamera::setEnvironmentMap(const bool environmentMap)
 {
-    osphelper::set(_camera, "environmentMap", environmentMap ? 1 : 0);
+    osphelper::set(_camera, "environmentMap", environmentMap);
     ospCommit(_camera);
 }
 

--- a/engines/ospray/OSPRayMaterial.cpp
+++ b/engines/ospray/OSPRayMaterial.cpp
@@ -57,7 +57,7 @@ void OSPRayMaterial::commit()
         return;
 
     if (getCurrentType() == "simulation")
-        osphelper::set(_ospMaterial, "apply_simulation", 1);
+        osphelper::set(_ospMaterial, "apply_simulation", true);
     else
         ospRemoveParam(_ospMaterial, "apply_simulation");
 

--- a/engines/ospray/OSPRayModel.cpp
+++ b/engines/ospray/OSPRayModel.cpp
@@ -297,7 +297,7 @@ void OSPRayModel::_commitStreamlines(const size_t materialId)
     }
 
     // Since we allow custom radius per point we always smooth
-    osphelper::set(geometry, "smooth", 1);
+    osphelper::set(geometry, "smooth", true);
 
     ospCommit(geometry);
 

--- a/engines/ospray/OSPRayScene.cpp
+++ b/engines/ospray/OSPRayScene.cpp
@@ -246,8 +246,7 @@ bool OSPRayScene::commitLights()
         osphelper::set(ospLight, "color", Vector3f(baseLight->_color));
         osphelper::set(ospLight, "intensity",
                        static_cast<float>(baseLight->_intensity));
-        // NOTE: Bool is broken before OSPRay 1.8.3 so set it to 1 or 0
-        osphelper::set(ospLight, "isVisible", baseLight->_isVisible ? 1 : 0);
+        osphelper::set(ospLight, "isVisible", baseLight->_isVisible);
 
         _ospLights.push_back(ospLight);
         ospCommit(ospLight);

--- a/engines/ospray/OSPRayVolume.cpp
+++ b/engines/ospray/OSPRayVolume.cpp
@@ -139,11 +139,10 @@ void OSPRayVolume::commit()
                        static_cast<float>(
                            _parameters.getAdaptiveMaxSamplingRate()));
         osphelper::set(_volume, "adaptiveSampling",
-                       _parameters.getAdaptiveSampling() ? 1 : 0);
-        osphelper::set(_volume, "singleShade",
-                       _parameters.getSingleShade() ? 1 : 0);
+                       _parameters.getAdaptiveSampling());
+        osphelper::set(_volume, "singleShade", _parameters.getSingleShade());
         osphelper::set(_volume, "preIntegration",
-                       _parameters.getPreIntegration() ? 1 : 0);
+                       _parameters.getPreIntegration());
         osphelper::set(_volume, "samplingRate",
                        static_cast<float>(_parameters.getSamplingRate()));
         osphelper::set(_volume, "specular",

--- a/engines/ospray/ispc/camera/PerspectiveCamera.cpp
+++ b/engines/ospray/ispc/camera/PerspectiveCamera.cpp
@@ -44,7 +44,8 @@ void PerspectiveCamera::commit()
     aspect = getParamf("aspect", 1.f);
     apertureRadius = getParamf("apertureRadius", 0.f);
     focusDistance = getParamf("focusDistance", 1.f);
-    stereo = getParam("stereo", false);
+    // FIXME(jonask): When supported by OSPRay use bool
+    stereo = getParam("stereo", 0);
     // the default 63.5mm represents the average human IPD
     interpupillaryDistance = getParamf("interpupillaryDistance", 0.0635f);
     clipPlanes = getParamData("clipPlanes", nullptr);

--- a/engines/ospray/ispc/render/ProximityRenderer.cpp
+++ b/engines/ospray/ispc/render/ProximityRenderer.cpp
@@ -34,10 +34,12 @@ void ProximityRenderer::commit()
     _nearColor = getParam3f("detectionNearColor", ospray::vec3f(0.f, 1.f, 0.f));
     _farColor = getParam3f("detectionFarColor", ospray::vec3f(1.f, 0.f, 0.f));
     _detectionDistance = getParam1f("detectionDistance", 1.f);
-    _detectionOnDifferentMaterial =
-        bool(getParam1i("detectionOnDifferentMaterial", 0));
-    _electronShadingEnabled = getParam("electronShadingEnabled", false);
-    _surfaceShadingEnabled = getParam("surfaceShadingEnabled", false);
+
+    // FIXME(jonask): When supported by OSPRay use bool
+    _detectionOnDifferentMaterial = getParam("detectionOnDifferentMaterial", 0);
+    _electronShadingEnabled = getParam("electronShadingEnabled", 0);
+    _surfaceShadingEnabled = getParam("surfaceShadingEnabled", 0);
+
     _randomNumber = getParam1i("randomNumber", 0);
     _alphaCorrection = getParam1f("alphaCorrection", 0.5f);
 

--- a/engines/ospray/utils.cpp
+++ b/engines/ospray/utils.cpp
@@ -112,8 +112,9 @@ void fromOSPRayProperties(PropertyMap& object, ospray::ManagedObject& ospObject)
                 ospObject.getParam1i(prop->name.c_str(), prop->get<int32_t>()));
             break;
         case Property::Type::Bool:
-            prop->set(
-                ospObject.getParam(prop->name.c_str(), prop->get<bool>()));
+            // FIXME(jonask): When supported by OSPRay use bool
+            prop->set(ospObject.getParam(prop->name.c_str(),
+                                         static_cast<bool>(prop->get<int>())));
             break;
         case Property::Type::String:
             prop->set(ospObject.getParamString(prop->name.c_str(),
@@ -176,10 +177,9 @@ ospcommon::affine3f transformationToAffine3f(
            ospcommon::affine3f::translate({float(rotationCenter.x),
                                            float(rotationCenter.y),
                                            float(rotationCenter.z)}) *
-           rot *
-           ospcommon::affine3f::translate({float(-rotationCenter.x),
-                                           float(-rotationCenter.y),
-                                           float(-rotationCenter.z)});
+           rot * ospcommon::affine3f::translate({float(-rotationCenter.x),
+                                                 float(-rotationCenter.y),
+                                                 float(-rotationCenter.z)});
 }
 
 void addInstance(OSPModel rootModel, OSPModel modelToAdd,
@@ -217,7 +217,8 @@ void set(OSPObject obj, const char* id, float v)
 }
 void set(OSPObject obj, const char* id, bool v)
 {
-    ospSet1b(obj, id, v);
+    // FIXME(jonask): When supported by OSPRay use bool
+    ospSet1i(obj, id, static_cast<int>(v));
 }
 void set(OSPObject obj, const char* id, int32_t v)
 {

--- a/plugins/CircuitViewer/renderer/SimulationMaterial.cpp
+++ b/plugins/CircuitViewer/renderer/SimulationMaterial.cpp
@@ -64,7 +64,8 @@ void SimulationMaterial::commit()
 
     DefaultMaterial::commit();
 
-    const bool withSimulationOffsets = getParam1i("apply_simulation", 0) == 1;
+    // FIXME(jonask): When supported by OSPRay use bool
+    const bool withSimulationOffsets = getParam1i("apply_simulation", 0);
     ispc::SimulationMaterial_set(getIE(), withSimulationOffsets);
 }
 


### PR DESCRIPTION
OSPRay always query bool parameters as int internally so we force all bools to ints until this is fixed.