### PR TITLE
fix(cpp): Rename default material to match OSPRay

### DIFF
--- a/engines/ospray/OSPRayMaterial.cpp
+++ b/engines/ospray/OSPRayMaterial.cpp
@@ -103,7 +103,7 @@ void OSPRayMaterial::commit(const std::string& renderer)
     if (!isModified() && renderer == _renderer)
         return;
     ospRelease(_ospMaterial);
-    _ospMaterial = ospNewMaterial2(renderer.c_str(), "default_material");
+    _ospMaterial = ospNewMaterial2(renderer.c_str(), "default");
     if (!_ospMaterial)
         throw std::runtime_error("Could not create material for renderer '" +
                                  renderer + "'");

--- a/engines/ospray/ispc/render/DefaultMaterial.cpp
+++ b/engines/ospray/ispc/render/DefaultMaterial.cpp
@@ -95,8 +95,8 @@ void DefaultMaterial::commit()
         (const ispc::LinearSpace2f&)rot_Bump);
 }
 
-OSP_REGISTER_MATERIAL(basic, DefaultMaterial, default_material);
-OSP_REGISTER_MATERIAL(BASIC, DefaultMaterial, default_material);
-OSP_REGISTER_MATERIAL(proximity, DefaultMaterial, default_material);
+OSP_REGISTER_MATERIAL(basic, DefaultMaterial, default);
+OSP_REGISTER_MATERIAL(BASIC, DefaultMaterial, default);
+OSP_REGISTER_MATERIAL(proximity, DefaultMaterial, default);
 
 } // ::brayns

--- a/plugins/CircuitViewer/renderer/SimulationMaterial.cpp
+++ b/plugins/CircuitViewer/renderer/SimulationMaterial.cpp
@@ -69,7 +69,6 @@ void SimulationMaterial::commit()
     ispc::SimulationMaterial_set(getIE(), withSimulationOffsets);
 }
 
-OSP_REGISTER_MATERIAL(advanced_simulation, SimulationMaterial,
-                      default_material);
-OSP_REGISTER_MATERIAL(basic_simulation, SimulationMaterial, default_material);
+OSP_REGISTER_MATERIAL(advanced_simulation, SimulationMaterial, default);
+OSP_REGISTER_MATERIAL(basic_simulation, SimulationMaterial, default);
 }

--- a/tests/myPlugin.cpp
+++ b/tests/myPlugin.cpp
@@ -142,7 +142,7 @@ public:
 };
 
 OSP_REGISTER_RENDERER(MyRenderer, myrenderer);
-OSP_REGISTER_MATERIAL(myrenderer, brayns::DefaultMaterial, default_material);
+OSP_REGISTER_MATERIAL(myrenderer, brayns::DefaultMaterial, default);
 
 extern "C" brayns::ExtensionPlugin* brayns_plugin_create(int argc,
                                                          const char** argv)


### PR DESCRIPTION
This fixes a bug where changing to a raycasting renderer caused a crash in OSPRay