### PR TITLE
fix normal discontinuity in SDF conePills

### DIFF
--- a/engines/ospray/ispc/geometry/SDFGeometries.ispc
+++ b/engines/ospray/ispc/geometry/SDFGeometries.ispc
@@ -45,6 +45,12 @@
 /////////////////////////////////////////////////////////////////////////////
 
 // https://en.wikipedia.org/wiki/Smoothstep
+inline float smoothstep(const float x)
+{
+    return x * x * (3 - 2 * x);
+}
+
+// https://en.wikipedia.org/wiki/Smoothstep
 inline float smootherstep(const float x)
 {
     return x * x * x * (x * (x * 6 - 15) + 10);
@@ -81,10 +87,12 @@ inline float sdConePill(const vec3f& p, const vec3f p0, const vec3f p1,
     const vec3f v = p1 - p0;
     const vec3f w = p - p0;
 
+    // distance to p0 along cone axis
     const float c1 = dot(w, v);
     if (c1 <= 0)
         return length(p - p0) - radius_bottom;
 
+    // cone length
     const float c2 = dot(v, v);
     if (c2 <= c1)
         return length(p - p1) - radius_top;
@@ -95,8 +103,7 @@ inline float sdConePill(const vec3f& p, const vec3f p0, const vec3f p1,
     const float thicknessAt = mix(radius_bottom, radius_top, b);
     const float thickness =
         useSigmoid
-            ? 0.5 * (thicknessAt +
-                     mix(radius_bottom, radius_top, smootherstep(b)))
+            ? mix(radius_bottom, radius_top, smootherstep(b))
             : thicknessAt;
 
     return length(p - Pb) - thickness;

--- a/tests/PDiffHelpers.h
+++ b/tests/PDiffHelpers.h
@@ -30,12 +30,13 @@
 
 #include <tests/paths.h>
 
+#include <iostream>
+
 #ifdef BRAYNS_USE_NETWORKING
 #include <ImageGenerator.h>
 #include <boost/filesystem.hpp>
 #include <brayns/common/utils/base64/base64.h>
 #include <fstream>
-#include <iostream>
 namespace fs = boost::filesystem;
 #endif
 


### PR DESCRIPTION
Cone pills implement a smooth profile (sigmoid-like). Unfortunately, this creates discontinuities in the normals as shown on this render:
![current_blend](https://user-images.githubusercontent.com/6662561/59281956-6b86e200-8c68-11e9-8d92-978fbcc766c0.png)

This pull request fixes this:
![smoother](https://user-images.githubusercontent.com/6662561/59282123-ae48ba00-8c68-11e9-8748-66e137be448b.png)

As explained in this [article](https://en.wikipedia.org/wiki/Smoothstep) we could use either the `smooth()` function, or the `smoother()` function, which have slightly different stepness.

Here using smooth:
![smooth](https://user-images.githubusercontent.com/6662561/59282200-cc161f00-8c68-11e9-93ed-c33c00dd4952.png)

I am not certain what is the better solution in this case.
