### PR TITLE
Preventing clip planes updates from broadcasting the whole scene

### DIFF
--- a/brayns/engine/Scene.cpp
+++ b/brayns/engine/Scene.cpp
@@ -200,7 +200,7 @@ bool Scene::empty() const
 size_t Scene::addClipPlane(const Plane& plane)
 {
     auto clipPlane = std::make_shared<ClipPlane>(plane);
-    clipPlane->onModified([&](const BaseObject&) { markModified(); });
+    clipPlane->onModified([&](const BaseObject&) { markModified(false); });
     _clipPlanes.emplace_back(std::move(clipPlane));
     markModified();
     return _clipPlanes.back()->getID();

--- a/engines/ospray/OSPRayScene.cpp
+++ b/engines/ospray/OSPRayScene.cpp
@@ -173,10 +173,6 @@ void OSPRayScene::commit()
     ospCommit(_rootModel);
 
     _computeBounds();
-
-    // TODO: triggers the change callback to re-broadcast the scene if the clip
-    // planes have changed. Provide an RPC to update/set clip planes.
-    markModified();
 }
 
 bool OSPRayScene::commitLights()


### PR DESCRIPTION
Little hack to prevent updates of clipping planes to trigger a broadcast of the whole scene. It has been a great improvement in the GUI performances.

The modifications have been supervised by the great Daniel itself.