### PR TITLE
Fix broken OptiX simulation data

### DIFF
--- a/engines/optix/OptiXModel.cpp
+++ b/engines/optix/OptiXModel.cpp
@@ -375,7 +375,7 @@ void OptiXModel::_commitSimulationDataImpl(const float* frameData,
 {
     auto context = OptiXContext::get().getOptixContext();
     setBufferRaw(RT_BUFFER_INPUT, RT_FORMAT_FLOAT, _simulationData,
-                 context["simulation_data"], frameData,
-                 frameSize * sizeof(float), frameSize * sizeof(float));
+                 context["simulation_data"], frameData, frameSize,
+                 frameSize * sizeof(float));
 }
 } // namespace brayns

--- a/engines/optix/cuda/renderer/TransferFunction.h
+++ b/engines/optix/cuda/renderer/TransferFunction.h
@@ -25,7 +25,7 @@ static __device__ inline T interpolateValues(const float v_min,
                                              const float value,
                                              optix::buffer<T, 1>& values)
 {
-    const int num_values = values.size() / sizeof(T);
+    const int num_values = values.size();
 
     const float v_clamped = min(v_max, max(v_min, value));
     const float range_per_value = (v_max - v_min) / (num_values - 1);


### PR DESCRIPTION
Simulation data buffer was bigger than needed.

The transfer function was using the number of bytes for the color values instead of the number of colors.