### PR TITLE
Support for controlled image streaming from client

### DIFF
--- a/plugins/Rockets/jsonSerialization.h
+++ b/plugins/Rockets/jsonSerialization.h
@@ -151,6 +151,11 @@ struct DirectoryFileList
     std::string message;
 };
 
+struct ImageStreamingMethod
+{
+    std::string type;
+};
+
 } // namespace brayns
 
 STATICJSON_DECLARE_ENUM(brayns::GeometryQuality,
@@ -594,6 +599,12 @@ inline void init(brayns::DirectoryFileList* a, ObjectHandler* h)
     h->add_property("dirs", &a->dirs);
     h->add_property("error", &a->error);
     h->add_property("message", &a->message);
+    h->set_flags(Flags::DisallowUnknownKey);
+}
+
+inline void init(brayns::ImageStreamingMethod* a, ObjectHandler* h)
+{
+    h->add_property("type", &a->type);
     h->set_flags(Flags::DisallowUnknownKey);
 }
 


### PR DESCRIPTION
Added entry points to switch between traditional streaming and controlled image streaming (Brayns wont send any frame until manually trigger from client)