### PR TITLE
Addons and fixes

### DIFF
--- a/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.cpp
+++ b/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.cpp
@@ -55,6 +55,7 @@
 #include <cstdio>
 #include <dirent.h>
 #include <fstream>
+#include <random>
 #include <regex>
 #include <unistd.h>
 
@@ -701,6 +702,14 @@ void CircuitExplorerPlugin::_setMaterialRange(const MaterialRangeDescriptor& mrd
                 matIds.push_back(static_cast<size_t>(id));
         }
 
+        if(mrd.diffuseColor.size() % 3 != 0)
+        {
+            PLUGIN_ERROR << "set-material-range: The diffuse colors component is not a multiple of 3" << std::endl;
+            return;
+        }
+
+        const size_t numColors = mrd.diffuseColor.size() / 3;
+
         for (const auto materialId : matIds)
         {
             try
@@ -709,9 +718,10 @@ void CircuitExplorerPlugin::_setMaterialRange(const MaterialRangeDescriptor& mrd
                     modelDescriptor->getModel().getMaterial(materialId);
                 if (material)
                 {
-                    material->setDiffuseColor({mrd.diffuseColor[0],
-                                               mrd.diffuseColor[1],
-                                               mrd.diffuseColor[2]});
+                    const size_t randomIndex = (rand() % numColors) * 3;
+                    material->setDiffuseColor({mrd.diffuseColor[randomIndex],
+                                               mrd.diffuseColor[randomIndex + 1],
+                                               mrd.diffuseColor[randomIndex + 2]});
                     material->setSpecularColor({mrd.specularColor[0],
                                                 mrd.specularColor[1],
                                                 mrd.specularColor[2]});

--- a/plugins/Rockets/jsonSerialization.h
+++ b/plugins/Rockets/jsonSerialization.h
@@ -156,6 +156,11 @@ struct ImageStreamingMethod
     std::string type;
 };
 
+struct ExitLaterSchedule
+{
+    uint32_t minutes;
+};
+
 } // namespace brayns
 
 STATICJSON_DECLARE_ENUM(brayns::GeometryQuality,
@@ -605,6 +610,12 @@ inline void init(brayns::DirectoryFileList* a, ObjectHandler* h)
 inline void init(brayns::ImageStreamingMethod* a, ObjectHandler* h)
 {
     h->add_property("type", &a->type);
+    h->set_flags(Flags::DisallowUnknownKey);
+}
+
+inline void init(brayns::ExitLaterSchedule* a, ObjectHandler* h)
+{
+    h->add_property("minutes", &a->minutes);
     h->set_flags(Flags::DisallowUnknownKey);
 }
 

--- a/python/brayns/plugins/circuit_explorer.py
+++ b/python/brayns/plugins/circuit_explorer.py
@@ -353,7 +353,7 @@ class CircuitExplorer:
         """
         params = dict()
         params['modelId'] = model_id
-        params['materialId'] = material_ids
+        params['materialIds'] = material_ids
         params['diffuseColor'] = diffuse_color
         params['specularColor'] = specular_color
         params['specularExponent'] = specular_exponent


### PR DESCRIPTION
- Fixed set_material_range python method (wrong parameter name)
- Using atomic flags for controlled streaming method
- Added random colouring through set-material-range
- Added exit-later entry point (will shutdown Brayns after a specific amount of minutes, allows reschedule)