### PR TITLE
Hot colorscheme switch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "CMake/common"]
-	path = CMake/common
-	url = https://github.com/Eyescale/CMake
 [submodule "uvw"]
 	path = deps/uvw
 	url = https://github.com/skypjack/uvw.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "deps/imgui"]
 	path = deps/imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "CMake/common"]
+	path = CMake/common
+	url = https://github.com/BlueBrain/CMake.git
+	branch = brayns_recursive_submodules

--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -10,9 +10,9 @@ endif()
 
 # Data access
 if(BRAYNS_CIRCUITVIEWER_ENABLED)
-  git_subproject(Brion https://github.com/BlueBrain/Brion.git 551fbb0)
+  git_subproject(Brion https://github.com/BlueBrain/Brion.git 39ad3483)
 endif()
 
-if(BRAYNS_BBIC_ENABLED)
+if(BRAYNS_BBIC_ENABLED AND NOT TARGET HighFive)
   git_subproject(HighFive https://github.com/BlueBrain/HighFive.git 68fbe8e)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(Brayns VERSION 1.0.1)
 set(Brayns_VERSION_ABI 1)
 
+set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+set(OpenGL_GL_PREFERENCE LEGACY)
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
                               ${CMAKE_SOURCE_DIR}/CMake/common)
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/CMake/common/Common.cmake)

--- a/brayns/common/simulation/AbstractSimulationHandler.h
+++ b/brayns/common/simulation/AbstractSimulationHandler.h
@@ -45,6 +45,13 @@ public:
 
     /** @return the current loaded frame for the simulation. */
     uint32_t getCurrentFrame() const { return _currentFrame; }
+
+    /**
+     * @brief Sets the current frame played by this simulation handler
+     * @param newFrame unsigned integer.
+     */
+    void setCurrentFrame(const uint32_t newFrame) { _currentFrame = newFrame; }
+
     /**
      * @brief returns a void pointer to the simulation data for the given frame
      * or nullptr if the frame is not loaded yet.

--- a/brayns/engine/Model.cpp
+++ b/brayns/engine/Model.cpp
@@ -399,6 +399,7 @@ void Model::logInformation()
     uint64_t nbCylinders = 0;
     uint64_t nbCones = 0;
     uint64_t nbSdfBeziers = 0;
+    uint64_t nbSdfGeoms = 0;
     uint64_t nbMeshes = _geometries->_triangleMeshes.size();
     for (const auto& spheres : _geometries->_spheres)
         nbSpheres += spheres.second.size();
@@ -408,11 +409,14 @@ void Model::logInformation()
         nbCones += cones.second.size();
     for (const auto& sdfBeziers : _geometries->_sdfBeziers)
         nbSdfBeziers += sdfBeziers.second.size();
+    for (const auto& sdfGeoms : _geometries->_sdf.geometryIndices)
+        nbSdfGeoms += sdfGeoms.second.size();
 
     BRAYNS_DEBUG << "Spheres: " << nbSpheres
                  << ", Cylinders: " << nbCylinders
                  << ", Cones: " << nbCones
                  << ", SDFBeziers: " << nbSdfBeziers
+                 << ", SDFGeometries: " << nbSdfGeoms
                  << ", Meshes: " << nbMeshes
                  << ", Memory: " << _sizeInBytes << " bytes ("
                  << _sizeInBytes / 1048576 << " MB), Bounds: " << _bounds
@@ -469,7 +473,12 @@ void Model::copyFrom(const Model& rhs)
         return;
 
     if (rhs._simulationHandler)
+    {
         _simulationHandler = rhs._simulationHandler->clone();
+        // Reset simulation handler current frame so the simulation data gets commited
+        // (current frame != animation params current frame)
+        _simulationHandler->setCurrentFrame(std::numeric_limits<uint32_t>::max());
+    }
 
     _transferFunction = rhs._transferFunction;
     _materials.clear();

--- a/brayns/engine/Scene.h
+++ b/brayns/engine/Scene.h
@@ -83,11 +83,34 @@ public:
     BRAYNS_API size_t addModel(ModelDescriptorPtr model);
 
     /**
+     * @brief Adds a model to the scene with the specific model id
+     * @param id to be used as model identifier
+     * @param model the model itself
+     */
+    BRAYNS_API void addModel(const size_t id, ModelDescriptorPtr model);
+
+    /**
         Removes a model from the scene
         @param id id of the model (descriptor)
         @return True if model was found and removed, false otherwise
       */
     BRAYNS_API bool removeModel(const size_t id);
+
+    /**
+     * @brief Check wether a model has been marked for replacement
+     *        for a new model
+     * @param id the ID of the model to replace the current one
+     * @return true if the model is on the list to be replaced
+     */
+    BRAYNS_API bool isMarkedForReplacement(const size_t id);
+
+    /**
+     * @brief Replaces an existing model (given its ID) for a new one
+     * @param id the ID of the model to replace
+     * @param modelDescriptor The model which will replace the current one
+     * @return True if the model was found and replace, false otherwise
+     */
+    BRAYNS_API bool replaceModel(const size_t id, ModelDescriptorPtr modelDescriptor);
 
     BRAYNS_API ModelDescriptorPtr getModel(const size_t id) const;
 
@@ -205,6 +228,8 @@ protected:
     size_t _modelID{0};
     ModelDescriptors _modelDescriptors;
     mutable std::shared_timed_mutex _modelMutex;
+
+    std::unordered_map<size_t, ModelDescriptorPtr> _markedForReplacement;
 
     LightManager _lightManager;
     ClipPlanes _clipPlanes;

--- a/brayns/io/MeshLoader.h
+++ b/brayns/io/MeshLoader.h
@@ -58,10 +58,18 @@ public:
                              const GeometryQuality geometryQuality) const;
 
 private:
+    struct MaterialInfo
+    {
+        std::string name;
+        size_t materialId;
+    };
+    typedef std::vector<MaterialInfo> MaterialInfoList;
+
     PropertyMap _defaults;
 
     void _createMaterials(Model& model, const aiScene* aiScene,
-                          const std::string& folder) const;
+                          const std::string& folder,
+                          MaterialInfoList& list) const;
 
     ModelMetadata _postLoad(const aiScene* aiScene, Model& model,
                             const Matrix4f& transformation,

--- a/engines/optix/OptiXScene.cpp
+++ b/engines/optix/OptiXScene.cpp
@@ -158,6 +158,20 @@ void OptiXScene::commit()
                        [](const auto& m) { return m->isMarkedForRemoval(); }),
         _modelDescriptors.end());
 
+    // Replace all models marked for replacement
+    for(auto& pair : _markedForReplacement)
+    {
+        auto it = std::find_if(std::begin(_modelDescriptors),
+                            std::end(_modelDescriptors),
+                            [checkId = pair.first](const auto& m)
+        {
+            return m->getModelID() == checkId;
+        });
+
+        if(it != std::end(_modelDescriptors))
+            *it = pair.second;
+    }
+
     auto context = OptiXContext::get().getOptixContext();
 
     auto values = std::map<TextureType, std::string>{

--- a/engines/ospray/ispc/geometry/RayMarching.isph
+++ b/engines/ospray/ispc/geometry/RayMarching.isph
@@ -97,8 +97,6 @@ inline float raymarching(const Ray& ray,
     float candidate_t = t0;
     float prev_radius = 0.f;
     float step_length = 0.f;
-    uniform int step_count = 0;
-    const uniform bool force_hit = true;
 
     // check if we start inside or outside of the shape
     float sdf_sign = (sdfDistance(ray.org, geo, prim, params) < 0 ? -1 : 1);
@@ -137,11 +135,9 @@ inline float raymarching(const Ray& ray,
             break;
 
         t += step_length;
-
-        step_count++;
     }
 
-    if (t > t1 || (candidate_error > pixel_radius && !force_hit))
+    if (t > t1 || candidate_error > pixel_radius)
         return -1.f;
 
     return candidate_t;

--- a/engines/ospray/ispc/geometry/SDFGeometries.ispc
+++ b/engines/ospray/ispc/geometry/SDFGeometries.ispc
@@ -94,9 +94,8 @@ inline float sdConePill(const vec3f& p, const vec3f p0, const vec3f p1,
     const float b = c1 / c2;
     const vec3f Pb = p0 + b * v;
 
-    const float thicknessAt = lerp(b, r0, r1);
     const float thickness =
-        useSigmoid ? lerp(smootherstep(b), r0, r1) : thicknessAt;
+        useSigmoid ? lerp(smootherstep(b), r0, r1) : lerp(b, r0, r1);
 
     return length(p - Pb) - thickness;
 }

--- a/plugins/CircuitExplorer/.gitsubprojects
+++ b/plugins/CircuitExplorer/.gitsubprojects
@@ -1,3 +1,5 @@
 # -*- mode: cmake -*-
-git_subproject(HighFive https://github.com/BlueBrain/HighFive.git 68fbe8e)
-git_subproject(Brion https://github.com/BlueBrain/Brion.git 551fbb0)
+git_subproject(Brion https://github.com/BlueBrain/Brion.git 39ad3483)
+if(NOT TARGET HighFive)
+    git_subproject(HighFive https://github.com/BlueBrain/HighFive.git 68fbe8e)
+endif()

--- a/plugins/CircuitExplorer/CMakeLists.txt
+++ b/plugins/CircuitExplorer/CMakeLists.txt
@@ -40,6 +40,7 @@ set(BRAYNSCIRCUITEXPLORER_SOURCES
     module/ispc/render/CellGrowthRenderer.cpp
     module/ispc/render/utils/CircuitExplorerAbstractRenderer.cpp
     module/ispc/render/utils/CircuitExplorerSimulationRenderer.cpp
+    plugin/api/CellObjectMapper.cpp
     plugin/api/CircuitExplorerParams.cpp
     plugin/meshing/MetaballsGenerator.cpp
     plugin/meshing/PointCloudMesher.cpp
@@ -61,7 +62,9 @@ set(BRAYNSCIRCUITEXPLORER_SOURCES
 )
 
 set(BRAYNSCIRCUITEXPLORER_PUBLIC_HEADERS
+    plugin/api/CellObjectMapper.h
     plugin/api/CircuitExplorerParams.h
+    plugin/api/MorphologyMap.h
     plugin/meshing/MetaballsGenerator.h
     plugin/meshing/PointCloudMesher.h
     plugin/CircuitExplorerPlugin.h

--- a/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.h
+++ b/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.h
@@ -22,6 +22,7 @@
 #ifndef MEMBRANELESS_ORGANELLES_PLUGIN_H
 #define MEMBRANELESS_ORGANELLES_PLUGIN_H
 
+#include <plugin/api/CellObjectMapper.h>
 #include <plugin/api/CircuitExplorerParams.h>
 #include <plugin/io/AbstractCircuitLoader.h>
 
@@ -48,34 +49,38 @@ public:
     void preRender() final;
     void postRender() final;
 
+    CellObjectMapper& getMapperForCircuit(const std::string& circuitFilePath);
+    void releaseCircuitMapper(const std::string& circuitFilePath);
+
 private:
     // Rendering
-    void _setCamera(const CameraDefinition&);
+    MessageResult _setCamera(const CameraDefinition&);
     CameraDefinition _getCamera();
-    void _setMaterial(const MaterialDescriptor&);
-    void _setMaterials(const MaterialsDescriptor&);
-    void _setMaterialRange(const MaterialRangeDescriptor&);
-    void _setMaterialExtraAttributes(const MaterialExtraAttributes&);
+    MessageResult _setMaterial(const MaterialDescriptor&);
+    MessageResult _setMaterials(const MaterialsDescriptor&);
+    MessageResult _setMaterialRange(const MaterialRangeDescriptor&);
+    MessageResult _setMaterialExtraAttributes(const MaterialExtraAttributes&);
 
     // Experimental
-    void _setSynapseAttributes(const SynapseAttributes&);
-    void _setConnectionsPerValue(const ConnectionsPerValue&);
-    void _setMetaballsPerSimulationValue(const MetaballsFromSimulationValue&);
-    void _saveModelToCache(const SaveModelToCache&);
+    MessageResult _setSynapseAttributes(const SynapseAttributes&);
+    MessageResult _setConnectionsPerValue(const ConnectionsPerValue&);
+    MessageResult _setMetaballsPerSimulationValue(const MetaballsFromSimulationValue&);
+    MessageResult _saveModelToCache(const SaveModelToCache&);
 
     // Handlers
-    void _attachCellGrowthHandler(const AttachCellGrowthHandler& payload);
-    void _attachCircuitSimulationHandler(
+    MessageResult _attachCellGrowthHandler(const AttachCellGrowthHandler& payload);
+    MessageResult _attachCircuitSimulationHandler(
         const AttachCircuitSimulationHandler& payload);
 
     // Movie production
-    void _exportFramesToDisk(const ExportFramesToDisk& payload);
+    MessageResult _exportFramesToDisk(const ExportFramesToDisk& payload);
     void _doExportFrameToDisk();
     FrameExportProgress _getFrameExportProgress();
-    void _makeMovie(const MakeMovieParameters& params);
+    ExportLayerToDiskResult _exportLayerToDisk(const ExportLayerToDisk& payload);
+    MessageResult _makeMovie(const MakeMovieParameters& params);
 
     // Anterograde tracing
-    AnterogradeTracingResult _traceAnterogrades(const AnterogradeTracing& payload);
+    MessageResult _traceAnterogrades(const AnterogradeTracing& payload);
 
     // Add geometry
     void _createShapeMaterial(brayns::ModelPtr& model,
@@ -89,10 +94,16 @@ private:
 
 
     // Predefined models
-    void _addGrid(const AddGrid& payload);
-    void _addColumn(const AddColumn& payload);
+    MessageResult _addGrid(const AddGrid& payload);
+    MessageResult _addColumn(const AddColumn& payload);
 
+    // Get material information
     MaterialIds _getMaterialIds(const ModelId& modelId);
+    MaterialDescriptor _getMaterial(const ModelMaterialId& mmId);
+
+    // Remap circuit colors to a specific scheme
+    MessageResult _remapCircuitToScheme(const RemapCircuit& payload);
+
     SynapseAttributes _synapseAttributes;
 
     bool _dirty{false};
@@ -101,5 +112,7 @@ private:
     bool _exportFramesToDiskDirty{false};
     uint16_t _frameNumber{0};
     int16_t _accumulationFrameNumber{0};
+
+    std::unordered_map<std::string, CellObjectMapper> _circuitMappers;
 };
 #endif

--- a/plugins/CircuitExplorer/plugin/api/CellObjectMapper.cpp
+++ b/plugins/CircuitExplorer/plugin/api/CellObjectMapper.cpp
@@ -1,0 +1,452 @@
+#include "CellObjectMapper.h"
+
+#include <brayns/common/types.h>
+
+#include <common/commonTypes.h>
+#include <common/log.h>
+
+#include <brayns/common/simulation/AbstractSimulationHandler.h>
+#include <brayns/engine/Material.h>
+
+#define NB_MATERIALS_PER_INSTANCE 3
+
+// ------------------------------------------------------------------------------
+
+void CellObjectMapper::setSourceModel(brayns::ModelDescriptorPtr model)
+{
+    _model = model;
+}
+
+void CellObjectMapper::add(const size_t gid, const MorphologyMap& mm)
+{
+    _cellToRenderableMap[gid] = mm;
+}
+
+void CellObjectMapper::remove(const size_t gid)
+{
+    auto it = _cellToRenderableMap.find(gid);
+    if(it != _cellToRenderableMap.end())
+        _cellToRenderableMap.erase(it);
+}
+
+RemapCircuitResult
+CellObjectMapper::remapCircuitColors(const CircuitColorScheme scheme,
+                                     brayns::Scene& scene)
+{
+    RemapCircuitResult result;
+    result.error = 0;
+    result.message = "";
+
+    if(scheme == _lastScheme)
+    {
+        result.error = 2;
+        result.message = "The requested scheme matches the active one";
+        return result;
+    }
+
+    PLUGIN_INFO << "Remapping circuit..." << std::endl;
+
+    // Gather current geometry mapping (material -> geometry list)
+    brayns::SpheresMap& srcSpheres = _model->getModel().getSpheres();
+    brayns::CylindersMap& srcCylinder = _model->getModel().getCylinders();
+    brayns::ConesMap& srcCones = _model->getModel().getCones();
+    brayns::SDFBeziersMap& srcBeziers = _model->getModel().getSDFBeziers();
+    brayns::TriangleMeshMap& srcMeshes = _model->getModel().getTriangleMeshes();
+
+    // New geometry mapping storage
+    brayns::SpheresMap remappedSpheres;
+    brayns::CylindersMap remappedCylinder;
+    brayns::ConesMap remappedCones;
+    brayns::SDFBeziersMap remappedBeziers;
+    brayns::TriangleMeshMap remappedMeshes;
+    brayns::SDFGeometryData remappedSDFGeometries = _model->getModel().getSDFGeometryData();
+    remappedSDFGeometries.geometryIndices.clear();
+
+    // Create the new model which will replace the current one
+    auto newModel = scene.createModel();
+
+    // Clear current scheme to material mapping
+    _data.etypes.materialMap.clear();
+    _data.layers.materialMap.clear();
+    _data.mtypes.materialMap.clear();
+    _data.targets.materialMap.clear();
+
+    try
+    {
+        // Copy the simulation handler
+        auto sh = _model->getModel().getSimulationHandler();
+        if(sh)
+            newModel->setSimulationHandler(sh);
+
+        // Copy the transfer function (only use for simulation)
+        auto& tf = _model->getModel().getTransferFunction();
+        newModel->getTransferFunction().setControlPoints(tf.getControlPoints());
+        newModel->getTransferFunction().setColorMap(tf.getColorMap());
+        newModel->getTransferFunction().setValuesRange(tf.getValuesRange());
+
+        // Create the new materials given the new scheme
+        brayns::PropertyMap materialProps;
+        materialProps.setProperty({MATERIAL_PROPERTY_CAST_USER_DATA, sh? true : false});
+        materialProps.setProperty({MATERIAL_PROPERTY_SHADING_MODE,
+                                   static_cast<int>(MaterialShadingMode::diffuse)});
+        materialProps.setProperty(
+            {MATERIAL_PROPERTY_CLIPPING_MODE,
+             static_cast<int>(MaterialClippingMode::no_clipping)});
+        for(size_t i = 0; i < _cellToRenderableMap.size(); ++i)
+        {
+            const auto matId = _computeMaterialId(scheme, i);
+            auto mptr = newModel->createMaterial(matId, std::to_string(matId), materialProps);
+            if(sh)
+                sh->bind(mptr);
+        }
+
+        // Remap item by item so we dont need to keep a whole second copy of
+        // the circuit
+        // Remap spheres
+        size_t i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            // If the model has spheres
+            auto& msm = pair.second._sphereMap;
+            if(!msm.empty())
+            {
+                // Recompute the material id for this morphology
+                const auto matId = _computeMaterialId(scheme, i);
+                // Add all the spheres of this morphology to the temporal storage
+                auto& tempStorage = remappedSpheres[matId];
+                // At the same time, rebuild the new morphology material id -> part map
+                std::vector<size_t> newMapping;
+                for(auto& spheres : msm)
+                {
+                    auto& src = srcSpheres[spheres.first];
+
+                    for(auto sphereIndx : spheres.second)
+                    {
+                        newMapping.push_back(tempStorage.size());
+                        tempStorage.push_back(src[sphereIndx]);
+                    }
+                }
+
+                // Update morphology map
+                pair.second._sphereMap.clear();
+                pair.second._sphereMap[matId] = newMapping;
+            }
+            i++;
+        }
+        newModel->getSpheres().insert(remappedSpheres.begin(), remappedSpheres.end());
+
+        // Remap cylinders
+        i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            auto& msm = pair.second._cylinderMap;
+            if(!msm.empty())
+            {
+                const auto matId = _computeMaterialId(scheme, i);
+                auto& tempStorage = remappedCylinder[matId];
+                std::vector<size_t> newMapping;
+                for(auto& cylinders : msm)
+                {
+                    auto& src = srcCylinder[cylinders.first];
+                    for(auto cylinderIndx : cylinders.second)
+                    {
+                        newMapping.push_back(tempStorage.size());
+                        tempStorage.push_back(src[cylinderIndx]);
+                    }
+                }
+
+                pair.second._cylinderMap.clear();
+                pair.second._cylinderMap[matId] = newMapping;
+            }
+            i++;
+        }
+        newModel->getCylinders().insert(remappedCylinder.begin(), remappedCylinder.end());
+
+        // Remap cones
+        i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            auto& msm = pair.second._coneMap;
+            if(!msm.empty())
+            {
+                const auto matId = _computeMaterialId(scheme, i);
+                auto& tempStorage = remappedCones[matId];
+                std::vector<size_t> newMapping;
+                for(auto& cones : msm)
+                {
+                    auto& src = srcCones[cones.first];
+                    for(auto coneIndx : cones.second)
+                    {
+                        newMapping.push_back(tempStorage.size());
+                        tempStorage.push_back(src[coneIndx]);
+                    }
+                }
+
+                pair.second._coneMap.clear();
+                pair.second._coneMap[matId] = newMapping;
+            }
+            i++;
+        }
+        newModel->getCones().insert(remappedCones.begin(), remappedCones.end());
+
+        // Remap Bezier SDFs
+        i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            auto& msm = pair.second._sdfBezierMap;
+            if(!msm.empty())
+            {
+                const auto matId = _computeMaterialId(scheme, i);
+                auto& tempStorage = remappedBeziers[matId];
+                std::vector<size_t> newMapping;
+                for(auto& beziers : msm)
+                {
+                    auto& src = srcBeziers[beziers.first];
+                    for(auto bezierIndx : beziers.second)
+                    {
+                        newMapping.push_back(tempStorage.size());
+                        tempStorage.push_back(src[bezierIndx]);
+                    }
+                }
+
+                pair.second._sdfBezierMap.clear();
+                pair.second._sdfBezierMap[matId] = newMapping;
+            }
+            i++;
+        }
+        newModel->getSDFBeziers().insert(remappedBeziers.begin(), remappedBeziers.end());
+
+        // Remap meshes
+        i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            if(pair.second._hasMesh)
+            {
+                const auto matId = _computeMaterialId(scheme, i);
+                remappedMeshes[matId] = srcMeshes[pair.second._triangleIndx];
+                pair.second._triangleIndx = matId;
+            }
+            i++;
+        }
+        newModel->getTriangleMeshes().insert(remappedMeshes.begin(), remappedMeshes.end());
+
+        // Remap Geometry SDFs
+        i = 0;
+        for(auto& pair : _cellToRenderableMap)
+        {
+            auto& msm = pair.second._sdfGeometryMap;
+            if(!msm.empty())
+            {
+                const auto matId = _computeMaterialId(scheme, i);
+                auto& tempStorage = remappedSDFGeometries.geometryIndices[matId];
+                for(auto& geometries : msm)
+                {
+                    for(auto geometryIndx : geometries.second)
+                        tempStorage.push_back(geometryIndx);
+                }
+            }
+            i++;
+        }
+        newModel->getSDFGeometryData() = remappedSDFGeometries;
+
+        // Model descriptor to hold the model
+        brayns::ModelDescriptorPtr modelDescriptor;
+
+        // Copy previous model transformation
+        brayns::Transformation transformation = _model->getTransformation();
+
+        // Create model descriptor
+        modelDescriptor =
+            std::make_shared<brayns::ModelDescriptor>(std::move(newModel), _model->getName(),
+                                                      _model->getPath(),
+                                                      _model->getMetadata());
+        modelDescriptor->setTransformation(transformation);
+
+        const size_t oldId = _model->getModelID();
+        _model = modelDescriptor;
+
+        // After remapping is done, execute needed tasks
+        // (Modify metadata, etc)
+        onCircuitColorFinish(scheme, MorphologyColorScheme::none);
+
+        // Set the new material colors to Brayn's default circuit color map
+        _applyDefaultColorMap();
+
+        // Replace current model with the new one
+        scene.addModel(oldId, modelDescriptor);
+
+        _lastScheme = scheme;
+        _lastMorphologyScheme = MorphologyColorScheme::none;
+    }
+    catch(std::exception& e)
+    {
+        result.error = 3;
+        result.message = "An exception occoured: " + std::string(e.what());
+    }
+
+    PLUGIN_INFO << "Remapping done!" << std::endl;
+
+    return result;
+}
+
+void CellObjectMapper::remapMorphologyColors(const MorphologyColorScheme scheme)
+{
+    if(scheme == _lastMorphologyScheme)
+        return;
+
+    _lastMorphologyScheme = scheme;
+    _lastScheme = CircuitColorScheme::none;
+}
+
+void CellObjectMapper::onCircuitColorFinish(const CircuitColorScheme& scheme,
+                                            const MorphologyColorScheme& mScheme)
+{
+    if(scheme != CircuitColorScheme::none)
+    {
+        if(scheme == CircuitColorScheme::by_layer)
+        {
+            std::string materialGroupsData = "[";
+            const SchemeItem& si = _data.layers;
+            std::set<size_t> uniqueIds;
+            uniqueIds.insert(si.ids.begin(), si.ids.end());
+            size_t counter = 0;
+            for(const auto id : uniqueIds)
+            {
+                auto matIdIt = si.materialMap.find(id);
+                auto nameIt = si.nameMap.find(id);
+                if(matIdIt != si.materialMap.end() &&
+                   nameIt != si.nameMap.end())
+                {
+                    counter++;
+                    const std::string ending = counter == si.materialMap.size()? "" : ",";
+                    materialGroupsData += "{\"name\":\""+nameIt->second+"\", "
+                                          "\"ids\":["+std::to_string(matIdIt->second)+"]}" + ending;
+                }
+            }
+            materialGroupsData += "]";
+
+            brayns::ModelMetadata newMetadata = _model->getMetadata();
+            newMetadata["materialGroups"] = materialGroupsData;
+            _model->setMetadata(newMetadata);
+        }
+        else
+        {
+            // If the "materialsGroup" field is present, remove it
+            // when remapping to a different scheme than by layer
+            const brayns::ModelMetadata& oldMetadata = _model->getMetadata();
+            auto it = oldMetadata.find("");
+            if(it != oldMetadata.end())
+            {
+                auto newMetadata = oldMetadata;
+                newMetadata.erase("materialsGroup");
+                _model->setMetadata(newMetadata);
+            }
+        }
+    }
+    else if(mScheme != MorphologyColorScheme::none)
+    {
+
+    }
+}
+
+CircuitSchemeData& CellObjectMapper::getSchemeData()
+{
+    return _data;
+}
+
+size_t CellObjectMapper::_computeMaterialId(const CircuitColorScheme scheme,
+                                            const size_t index)
+{
+    size_t materialId = 0;
+    switch (scheme)
+    {
+    case CircuitColorScheme::by_id:
+        materialId = NB_MATERIALS_PER_INSTANCE * index;
+        break;
+    case CircuitColorScheme::by_target:
+        if(!_data.targets.ids.empty())
+        {
+            for (size_t i = 0; i < _data.targets.ids.size() - 1; ++i)
+                if (index >= _data.targets.ids[i] && index < _data.targets.ids[i + 1])
+                {
+                    materialId = NB_MATERIALS_PER_INSTANCE * i;
+                    _data.targets.materialMap[i] = materialId;
+                    break;
+                }
+        }
+        break;
+    case CircuitColorScheme::by_etype:
+        if (index < _data.etypes.ids.size())
+        {
+            const auto etypeId = _data.etypes.ids[index];
+            materialId =
+                NB_MATERIALS_PER_INSTANCE * etypeId;
+            _data.etypes.materialMap[etypeId] = materialId;
+        }
+        else
+            PLUGIN_DEBUG << "Failed to get neuron E-type" << std::endl;
+        break;
+    case CircuitColorScheme::by_mtype:
+        if (index < _data.mtypes.ids.size())
+        {
+            const auto mtypeId = _data.mtypes.ids[index];
+            materialId = NB_MATERIALS_PER_INSTANCE * mtypeId;
+            _data.mtypes.materialMap[mtypeId] = materialId;
+        }
+        else
+            PLUGIN_DEBUG << "Failed to get neuron M-type" << std::endl;
+        break;
+    case CircuitColorScheme::by_layer:
+        if (index < _data.layers.ids.size())
+        {
+            const auto layerId = _data.layers.ids[index];
+            materialId = NB_MATERIALS_PER_INSTANCE * layerId;
+            _data.layers.materialMap[layerId] = materialId;
+        }
+        else
+            PLUGIN_DEBUG << "Failed to get neuron layer" << std::endl;
+        break;
+    default:
+        materialId = brayns::NO_MATERIAL;
+    }
+
+    return materialId;
+}
+
+void CellObjectMapper::_applyDefaultColorMap() const
+{
+    const static std::vector<brayns::Vector3d> colors = {
+        {0.8941176470588236, 0.10196078431372549, 0.10980392156862745},
+        {0.21568627450980393, 0.49411764705882355, 0.7215686274509804},
+        {0.30196078431372547, 0.6862745098039216, 0.2901960784313726},
+        {0.596078431372549, 0.3058823529411765, 0.6392156862745098},
+        {1.0, 0.4980392156862745, 0.0},
+        {1.0, 1.0, 0.2},
+        {0.6509803921568628, 0.33725490196078434, 0.1568627450980392},
+        {0.9686274509803922, 0.5058823529411764, 0.7490196078431373},
+        {0.6, 0.6, 0.6},
+        {0.8941176470588236, 0.10196078431372549, 0.10980392156862745},
+        {0.21568627450980393, 0.49411764705882355, 0.7215686274509804},
+        {0.30196078431372547, 0.6862745098039216, 0.2901960784313726},
+        {0.596078431372549, 0.3058823529411765, 0.6392156862745098},
+        {1.0, 0.4980392156862745, 0.0},
+        {1.0, 1.0, 0.2},
+        {0.6509803921568628, 0.33725490196078434, 0.1568627450980392},
+        {0.9686274509803922, 0.5058823529411764, 0.7490196078431373},
+        {0.6, 0.6, 0.6},
+        {0.8941176470588236, 0.10196078431372549, 0.10980392156862745},
+        {0.21568627450980393, 0.49411764705882355, 0.7215686274509804}};
+
+    uint64_t i = 0;
+    auto &materials = _model->getModel().getMaterials();
+    for (auto &material : materials)
+    {
+        if(material.first != brayns::SECONDARY_MODEL_MATERIAL_ID
+           && material.first != brayns::BOUNDINGBOX_MATERIAL_ID)
+        {
+            const auto &color = colors[i % colors.size()];
+            material.second->setDiffuseColor(color);
+            ++i;
+        }
+    }
+}

--- a/plugins/CircuitExplorer/plugin/api/CellObjectMapper.h
+++ b/plugins/CircuitExplorer/plugin/api/CellObjectMapper.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2020, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Nadir Román Guerrero <nadir.romanguerrero@epfl.ch>
+ *
+ * This file is part of the circuit explorer for Brayns
+ * <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef CELLOBJECTMAPPER_H
+#define CELLOBJECTMAPPER_H
+
+#include <brayns/common/types.h>
+
+#include <brayns/engine/Model.h>
+#include <brayns/engine/Scene.h>
+
+#include <common/types.h>
+
+#include "MorphologyMap.h"
+
+struct SchemeItem
+{
+  size_ts ids;
+  std::unordered_map<size_t, size_t> materialMap;
+  std::unordered_map<size_t, std::string> nameMap;
+};
+
+struct CircuitSchemeData
+{
+    SchemeItem targets;
+    SchemeItem etypes;
+    SchemeItem mtypes;
+    SchemeItem layers;
+};
+
+struct RemapCircuitResult
+{
+    int error;
+    std::string message;
+};
+
+class CellObjectMapper
+{
+public:
+    void setSourceModel(brayns::ModelDescriptorPtr model);
+    void setCircuitSchemes(const CircuitSchemeData& data);
+
+    void add(const size_t gid, const MorphologyMap& mm);
+    void remove(const size_t gid);
+
+    RemapCircuitResult remapCircuitColors(const CircuitColorScheme scheme,
+                                          brayns::Scene& scene);
+    void remapMorphologyColors(const MorphologyColorScheme scheme);
+
+    void onCircuitColorFinish(const CircuitColorScheme& scheme,
+                              const MorphologyColorScheme& mScheme);
+
+    CircuitSchemeData& getSchemeData();
+
+private:
+    size_t _computeMaterialId(const CircuitColorScheme scheme,
+                              const size_t index);
+
+    void _applyDefaultColorMap() const;
+
+private:
+    brayns::ModelDescriptorPtr _model;
+
+    CircuitSchemeData _data;
+
+    CircuitColorScheme _lastScheme{CircuitColorScheme::none};
+    MorphologyColorScheme _lastMorphologyScheme{MorphologyColorScheme::none};
+
+    // Maps GIDs to all the pieces that forms the morphology of the given cell
+    std::unordered_map<size_t, MorphologyMap> _cellToRenderableMap;
+};
+
+#endif

--- a/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.cpp
+++ b/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.cpp
@@ -24,6 +24,8 @@
 
 #include <common/log.h>
 
+#include <exception>
+
 #ifndef BRAYNS_DEBUG_JSON_ENABLED
 #define FROM_JSON(PARAM, JSON, NAME) \
     PARAM.NAME = JSON[#NAME].get<decltype(PARAM.NAME)>()
@@ -34,7 +36,7 @@
     } \
     catch(...){ \
         PLUGIN_ERROR << "JSON parsing error for attribute '" << #NAME<< "'!" << std::endl; \
-        throw; \
+        throw std::runtime_error("AttributeError: " + std::string(#NAME)); \
     }
 #endif
 #define TO_JSON(PARAM, JSON, NAME) JSON[#NAME] = PARAM.NAME
@@ -72,6 +74,23 @@ std::string to_json(const Result& param)
     return "";
 }
 
+std::string to_json(const MessageResult& result)
+{
+    try
+    {
+        nlohmann::json js;
+
+        TO_JSON(result, js, error);
+        TO_JSON(result, js, message);
+        return js.dump();
+    }
+    catch (...)
+    {
+        return "";
+    }
+    return "";
+}
+
 bool from_json(SaveModelToCache& param, const std::string& payload)
 {
     try
@@ -80,9 +99,10 @@ bool from_json(SaveModelToCache& param, const std::string& payload)
         FROM_JSON(param, js, modelId);
         FROM_JSON(param, js, path);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -107,11 +127,42 @@ bool from_json(MaterialDescriptor& param, const std::string& payload)
         FROM_JSON(param, js, clippingMode);
         FROM_JSON(param, js, userParameter);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
+}
+
+std::string to_json(const MaterialDescriptor& payload)
+{
+    try
+    {
+        nlohmann::json js;
+        TO_JSON(payload, js, modelId);
+        TO_JSON(payload, js, materialId);
+        TO_JSON(payload, js, diffuseColor);
+        TO_JSON(payload, js, specularColor);
+        TO_JSON(payload, js, specularExponent);
+        TO_JSON(payload, js, reflectionIndex);
+        TO_JSON(payload, js, opacity);
+        TO_JSON(payload, js, refractionIndex);
+        TO_JSON(payload, js, emission);
+        TO_JSON(payload, js, glossiness);
+        TO_JSON(payload, js, simulationDataCast);
+        TO_JSON(payload, js, shadingMode);
+        TO_JSON(payload, js, clippingMode);
+        TO_JSON(payload, js, userParameter);
+        TO_JSON(payload, js, error);
+        TO_JSON(payload, js, message);
+        return js.dump();
+    }
+    catch (...)
+    {
+        return "";
+    }
+    return "";
 }
 
 bool from_json(MaterialsDescriptor& param, const std::string& payload)
@@ -134,9 +185,10 @@ bool from_json(MaterialsDescriptor& param, const std::string& payload)
         FROM_JSON(param, js, clippingModes);
         FROM_JSON(param, js, userParameters);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -162,9 +214,10 @@ bool from_json(MaterialRangeDescriptor& param,
         FROM_JSON(param, js, clippingMode);
         FROM_JSON(param, js, userParameter);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -176,9 +229,26 @@ bool from_json(ModelId& param, const std::string& payload)
         auto js = nlohmann::json::parse(payload);
         FROM_JSON(param, js, modelId);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
+    }
+    return true;
+}
+
+bool from_json(ModelMaterialId& mmId, const std::string& payload)
+{
+    try
+    {
+        auto js = nlohmann::json::parse(payload);
+        FROM_JSON(mmId, js, modelId);
+        FROM_JSON(mmId, js, materialId);
+    }
+    catch (const std::exception& e)
+    {
+        mmId.parsed = false;
+        mmId.parseError = std::string(e.what());
     }
     return true;
 }
@@ -189,6 +259,8 @@ std::string to_json(const MaterialIds& param)
     {
         nlohmann::json js;
         TO_JSON(param, js, ids);
+        TO_JSON(param, js, error);
+        TO_JSON(param, js, message);
         return js.dump();
     }
     catch (...)
@@ -209,9 +281,10 @@ bool from_json(SynapseAttributes& param, const std::string& payload)
         FROM_JSON(param, js, lightEmission);
         FROM_JSON(param, js, radius);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -223,9 +296,10 @@ bool from_json(CircuitBoundingBox& param, const std::string& payload)
         auto js = nlohmann::json::parse(payload);
         FROM_JSON(param, js, aabb);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -240,9 +314,10 @@ bool from_json(ConnectionsPerValue& param, const std::string& payload)
         FROM_JSON(param, js, value);
         FROM_JSON(param, js, epsilon);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -259,9 +334,10 @@ bool from_json(MetaballsFromSimulationValue& param, const std::string& payload)
         FROM_JSON(param, js, gridSize);
         FROM_JSON(param, js, threshold);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -273,9 +349,10 @@ bool from_json(MaterialExtraAttributes& param, const std::string& payload)
         auto js = nlohmann::json::parse(payload);
         FROM_JSON(param, js, modelId);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -292,9 +369,10 @@ bool from_json(LoadCellsAsInstances& param, const std::string& payload)
         FROM_JSON(param, js, morphologyFolder);
         FROM_JSON(param, js, morphologyExtension);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -308,9 +386,10 @@ bool from_json(ImportMorphology& param, const std::string& payload)
         FROM_JSON(param, js, guid);
         FROM_JSON(param, js, filename);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -326,9 +405,10 @@ bool from_json(LoadCells& param, const std::string& payload)
         FROM_JSON(param, js, sqlMorphology);
         FROM_JSON(param, js, sdf);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -344,9 +424,10 @@ bool from_json(LoadSomas& param, const std::string& payload)
         FROM_JSON(param, js, radius);
         FROM_JSON(param, js, showOrientations);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -361,9 +442,10 @@ bool from_json(LoadSegments& param, const std::string& payload)
         FROM_JSON(param, js, name);
         FROM_JSON(param, js, radius);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -376,9 +458,10 @@ bool from_json(LoadMeshes& param, const std::string& payload)
         FROM_JSON(param, js, connectionString);
         FROM_JSON(param, js, sqlStatement);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -394,9 +477,10 @@ bool from_json(ImportVolume& param, const std::string& payload)
         FROM_JSON(param, js, spacing);
         FROM_JSON(param, js, rawFilename);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -410,9 +494,10 @@ bool from_json(ImportCompartmentSimulation& param, const std::string& payload)
         FROM_JSON(param, js, blueConfig);
         FROM_JSON(param, js, reportName);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -426,9 +511,10 @@ bool from_json(CameraDefinition& param, const std::string& payload)
         FROM_JSON(param, js, direction);
         FROM_JSON(param, js, up);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -444,6 +530,8 @@ std::string to_json(const CameraDefinition& param)
         TO_JSON(param, js, up);
         TO_JSON(param, js, apertureRadius);
         TO_JSON(param, js, focusDistance);
+        TO_JSON(param, js, error);
+        TO_JSON(param, js, message);
         return js.dump();
     }
     catch (...)
@@ -461,9 +549,10 @@ bool from_json(AttachCellGrowthHandler& param, const std::string& payload)
         FROM_JSON(param, js, modelId);
         FROM_JSON(param, js, nbFrames);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -479,9 +568,10 @@ bool from_json(AttachCircuitSimulationHandler& param,
         FROM_JSON(param, js, reportName);
         FROM_JSON(param, js, synchronousMode);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -499,9 +589,10 @@ bool from_json(ExportFramesToDisk& param, const std::string& payload)
         FROM_JSON(param, js, animationInformation);
         FROM_JSON(param, js, cameraInformation);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -512,6 +603,44 @@ std::string to_json(const FrameExportProgress& exportProgress)
     {
         nlohmann::json json;
         TO_JSON(exportProgress, json, progress);
+        TO_JSON(exportProgress, json, error);
+        TO_JSON(exportProgress, json, message);
+        return json.dump();
+    }
+    catch (...)
+    {
+        return "";
+    }
+    return "";
+}
+
+bool from_json(ExportLayerToDisk& param, const std::string& payload)
+{
+    try
+    {
+        auto json = nlohmann::json::parse(payload);
+        FROM_JSON(param, json, path);
+        FROM_JSON(param, json, name);
+        FROM_JSON(param, json, startFrame);
+        FROM_JSON(param, json, framesCount);
+        FROM_JSON(param, json, data);
+    }
+    catch (const std::exception& e)
+    {
+        param.parsed = false;
+        param.parseError = std::string(e.what());
+    }
+    return true;
+}
+
+std::string to_json(const ExportLayerToDiskResult& result)
+{
+    try
+    {
+        nlohmann::json json;
+        TO_JSON(result, json, frames);
+        TO_JSON(result, json, error);
+        TO_JSON(result, json, message);
         return json.dump();
     }
     catch (...)
@@ -532,10 +661,12 @@ bool from_json(MakeMovieParameters& movieParams, const std::string& payload)
         FROM_JSON(movieParams, json, fpsRate);
         FROM_JSON(movieParams, json, outputMoviePath);
         FROM_JSON(movieParams, json, eraseFrames);
+        FROM_JSON(movieParams, json, layers);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        movieParams.parsed = false;
+        movieParams.parseError = std::string(e.what());
     }
     return true;
 }
@@ -553,9 +684,10 @@ bool from_json(AddGrid& param, const std::string& payload)
         FROM_JSON(param, js, showAxis);
         FROM_JSON(param, js, useColors);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -567,9 +699,10 @@ bool from_json(AddColumn& param, const std::string& payload)
         auto js = nlohmann::json::parse(payload);
         FROM_JSON(param, js, radius);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -586,27 +719,12 @@ bool from_json(AnterogradeTracing& param, const std::string& payload)
         FROM_JSON(param, js, connectedCellsColor);
         FROM_JSON(param, js, nonConnectedCellsColor);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
-}
-
-std::string to_json(const AnterogradeTracingResult& result)
-{
-    try
-    {
-        nlohmann::json json;
-        TO_JSON(result, json, error);
-        TO_JSON(result, json, message);
-        return json.dump();
-    }
-    catch (...)
-    {
-        return "";
-    }
-    return "";
 }
 
 bool from_json(AddSphere& param, const std::string& payload)
@@ -619,9 +737,10 @@ bool from_json(AddSphere& param, const std::string& payload)
         FROM_JSON(param, js, radius);
         FROM_JSON(param, js, color);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -639,9 +758,10 @@ bool from_json(AddPill& param, const std::string& payload)
         FROM_JSON(param, js, radius2);
         FROM_JSON(param, js, color);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -657,9 +777,10 @@ bool from_json(AddCylinder& param, const std::string& payload)
         FROM_JSON(param, js, radius);
         FROM_JSON(param, js, color);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -674,9 +795,10 @@ bool from_json(AddBox& param, const std::string& payload)
         FROM_JSON(param, js, maxCorner);
         FROM_JSON(param, js, color);
     }
-    catch (...)
+    catch (const std::exception& e)
     {
-        return false;
+        param.parsed = false;
+        param.parseError = std::string(e.what());
     }
     return true;
 }
@@ -696,4 +818,20 @@ std::string to_json(const AddShapeResult& addResult)
         return "";
     }
     return "";
+}
+
+bool from_json(RemapCircuit& param, const std::string& payload)
+{
+    try
+    {
+        auto js = nlohmann::json::parse(payload);
+        FROM_JSON(param, js, modelId);
+        FROM_JSON(param, js, scheme);
+    }
+    catch (const std::exception& e)
+    {
+        param.parsed = false;
+        param.parseError = std::string(e.what());
+    }
+    return true;
 }

--- a/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.h
+++ b/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.h
@@ -19,8 +19,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CIRCUITVIEWERPARAMS_H
-#define CIRCUITVIEWERPARAMS_H
+#ifndef CIRCUITEXPLORERPARAMS_H
+#define CIRCUITEXPLORERPARAMS_H
 
 #include "../../common/types.h"
 #include <brayns/common/types.h>
@@ -33,16 +33,26 @@ struct Result
 
 std::string to_json(const Result& param);
 
+struct MessageResult
+{
+    int error{0};
+    std::string message{""};
+};
+
+std::string to_json(const MessageResult& result);
+
 /** Save model to cache */
 struct SaveModelToCache
 {
     int32_t modelId;
     std::string path;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(SaveModelToCache& modelSave, const std::string& payload);
 
-struct MaterialDescriptor
+struct MaterialDescriptor : public MessageResult
 {
     int32_t modelId;
     int32_t materialId;
@@ -58,10 +68,13 @@ struct MaterialDescriptor
     int32_t shadingMode;
     int32_t clippingMode;
     float userParameter;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(MaterialDescriptor& materialDescriptor,
                const std::string& payload);
+std::string to_json(const MaterialDescriptor& payload);
 
 struct MaterialsDescriptor
 {
@@ -79,6 +92,8 @@ struct MaterialsDescriptor
     std::vector<int32_t> shadingModes;
     std::vector<int32_t> clippingModes;
     std::vector<float> userParameters;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(MaterialsDescriptor& materialsDescriptor,
@@ -100,6 +115,8 @@ struct MaterialRangeDescriptor
     int32_t shadingMode;
     int32_t clippingMode;
     float userParameter;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(MaterialRangeDescriptor& materialRangeDescriptor,
@@ -109,11 +126,21 @@ bool from_json(MaterialRangeDescriptor& materialRangeDescriptor,
 struct ModelId
 {
     size_t modelId;
+    bool parsed{true};
+    std::string parseError{""};
 };
-
 bool from_json(ModelId& modelId, const std::string& payload);
 
-struct MaterialIds
+struct ModelMaterialId
+{
+    size_t modelId;
+    size_t materialId;
+    bool parsed{true};
+    std::string parseError{""};
+};
+bool from_json(ModelMaterialId& mmId, const std::string& payload);
+
+struct MaterialIds : public MessageResult
 {
     std::vector<size_t> ids;
 };
@@ -128,6 +155,8 @@ struct SynapseAttributes
     std::vector<std::string> htmlColors;
     float lightEmission;
     float radius;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(SynapseAttributes& synapseAttributes,
@@ -137,6 +166,8 @@ bool from_json(SynapseAttributes& synapseAttributes,
 struct CircuitBoundingBox
 {
     std::vector<double> aabb{0, 0, 0, 0, 0, 0};
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(CircuitBoundingBox& circuitBoundingBox,
@@ -149,6 +180,8 @@ struct ConnectionsPerValue
     int32_t frame;
     double value;
     double epsilon;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(ConnectionsPerValue& connectionsPerValue,
@@ -163,6 +196,8 @@ struct MetaballsFromSimulationValue
     double epsilon;
     int32_t gridSize;
     double threshold;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(MetaballsFromSimulationValue& param, const std::string& payload);
@@ -171,6 +206,8 @@ bool from_json(MetaballsFromSimulationValue& param, const std::string& payload);
 struct MaterialExtraAttributes
 {
     int32_t modelId;
+    bool parsed{true};
+    std::string parseError{""};
 };
 
 bool from_json(MaterialExtraAttributes& param, const std::string& payload);
@@ -184,6 +221,8 @@ struct LoadCellsAsInstances
     std::string description;
     std::string morphologyFolder;
     std::string morphologyExtension;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(LoadCellsAsInstances& param, const std::string& payload);
 
@@ -192,6 +231,8 @@ struct ImportMorphology
     std::string connectionString;
     uint64_t guid;
     std::string filename;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(ImportMorphology& param, const std::string& payload);
 
@@ -202,6 +243,8 @@ struct LoadCells
     std::string sqlCell;
     std::string sqlMorphology;
     bool sdf;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(LoadCells& param, const std::string& payload);
 
@@ -212,6 +255,8 @@ struct LoadSomas
     std::string name;
     float radius{1.f};
     bool showOrientations;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(LoadSomas& param, const std::string& payload);
 
@@ -221,6 +266,8 @@ struct LoadSegments
     std::string sqlStatement;
     std::string name;
     float radius{1.f};
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(LoadSegments& param, const std::string& payload);
 
@@ -228,6 +275,8 @@ struct LoadMeshes
 {
     std::string connectionString;
     std::string sqlStatement;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(LoadMeshes& param, const std::string& payload);
 
@@ -238,6 +287,8 @@ struct ImportVolume
     std::vector<uint16_t> dimensions;
     std::vector<float> spacing;
     std::string rawFilename;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(ImportVolume& param, const std::string& payload);
 
@@ -246,16 +297,20 @@ struct ImportCompartmentSimulation
     std::string connectionString;
     std::string blueConfig;
     std::string reportName;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(ImportCompartmentSimulation& param, const std::string& payload);
 
-struct CameraDefinition
+struct CameraDefinition : public MessageResult
 {
     std::vector<double> origin;
     std::vector<double> direction;
     std::vector<double> up;
     double apertureRadius;
     double focusDistance;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(CameraDefinition& param, const std::string& payload);
 std::string to_json(const CameraDefinition& param);
@@ -264,6 +319,8 @@ struct AttachCellGrowthHandler
 {
     uint64_t modelId;
     uint64_t nbFrames;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AttachCellGrowthHandler& param, const std::string& payload);
 
@@ -273,6 +330,8 @@ struct AttachCircuitSimulationHandler
     std::string circuitConfiguration;
     std::string reportName;
     bool synchronousMode;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AttachCircuitSimulationHandler& param,
                const std::string& payload);
@@ -286,14 +345,34 @@ struct ExportFramesToDisk
     uint16_t startFrame{0};
     std::vector<uint64_t> animationInformation;
     std::vector<double> cameraInformation;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(ExportFramesToDisk& param, const std::string& payload);
 
-struct FrameExportProgress
+struct FrameExportProgress : public MessageResult
 {
     float progress;
 };
 std::string to_json(const FrameExportProgress& exportProgress);
+
+struct ExportLayerToDisk
+{
+    std::string path;
+    std::string name;
+    uint32_t startFrame;
+    uint32_t framesCount;
+    std::string data;
+    bool parsed{true};
+    std::string parseError{""};
+};
+bool from_json(ExportLayerToDisk& param, const std::string& payload);
+
+struct ExportLayerToDiskResult : public MessageResult
+{
+    std::vector<uint32_t> frames;
+};
+std::string to_json(const ExportLayerToDiskResult& result);
 
 struct MakeMovieParameters
 {
@@ -303,6 +382,9 @@ struct MakeMovieParameters
     uint32_t fpsRate;
     std::string outputMoviePath;
     bool eraseFrames;
+    strings layers;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(MakeMovieParameters& movieParams, const std::string& payload);
 
@@ -315,12 +397,16 @@ struct AddGrid
     float planeOpacity;
     bool showAxis;
     bool useColors;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddGrid& param, const std::string& payload);
 
 struct AddColumn
 {
     float radius;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddColumn& param, const std::string& payload);
 
@@ -332,15 +418,10 @@ struct AnterogradeTracing
     std::vector<double> sourceCellColor;
     std::vector<double> connectedCellsColor;
     std::vector<double> nonConnectedCellsColor;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AnterogradeTracing& param, const std::string& payload);
-
-struct AnterogradeTracingResult
-{
-    int error;
-    std::string message;
-};
-std::string to_json(const AnterogradeTracingResult& result);
 
 struct AddSphere
 {
@@ -348,6 +429,8 @@ struct AddSphere
     std::vector<float> center;
     float radius;
     std::vector<double> color;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddSphere& param, const std::string& payload);
 
@@ -360,6 +443,8 @@ struct AddPill
     float radius1;
     float radius2;
     std::vector<double> color;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddPill& param, const std::string& payload);
 
@@ -370,6 +455,8 @@ struct AddCylinder
     std::vector<float> up;
     float radius;
     std::vector<double> color;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddCylinder& param, const std::string& payload);
 
@@ -379,15 +466,24 @@ struct AddBox
     std::vector<float> minCorner;
     std::vector<float> maxCorner;
     std::vector<double> color;
+    bool parsed{true};
+    std::string parseError{""};
 };
 bool from_json(AddBox& param, const std::string& payload);
 
-struct AddShapeResult
+struct AddShapeResult : public MessageResult
 {
     size_t id;
-    int error;
-    std::string message;
 };
 std::string to_json(const AddShapeResult& addResult);
+
+struct RemapCircuit
+{
+    uint32_t modelId;
+    std::string scheme;
+    bool parsed{true};
+    std::string parseError{""};
+};
+bool from_json(RemapCircuit& param, const std::string& payload);
 
 #endif // CIRCUITVIEWERPARAMS_H

--- a/plugins/CircuitExplorer/plugin/api/MorphologyMap.h
+++ b/plugins/CircuitExplorer/plugin/api/MorphologyMap.h
@@ -1,0 +1,57 @@
+/* Copyright (c) 2020, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Nadir Román Guerrero <nadir.romanguerrero@epfl.ch>
+ *
+ * This file is part of the circuit explorer for Brayns
+ * <https://github.com/BlueBrain/Brayns>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MORPHOLOGYMAP_H
+#define MORPHOLOGYMAP_H
+
+#include <brayns/common/geometry/Sphere.h>
+#include <brayns/common/geometry/Cylinder.h>
+#include <brayns/common/geometry/Cone.h>
+#include <brayns/common/geometry/SDFBezier.h>
+#include <brayns/common/geometry/TriangleMesh.h>
+#include <brayns/common/geometry/SDFGeometry.h>
+#include <brayns/common/types.h>
+
+#include <unordered_map>
+
+struct MorphologyMap
+{
+    // material Id -> list of spheres for this morhpology
+    std::unordered_map<size_t, std::vector<size_t>> _sphereMap;
+
+    // material Id -> list of cylinder for this morpholgy
+    std::unordered_map<size_t, std::vector<size_t>> _cylinderMap;
+
+    // material Id -> list of cones for this morphology
+    std::unordered_map<size_t, std::vector<size_t>> _coneMap;
+
+    // material Id -> list of bezier sdfs for this morhology
+    std::unordered_map<size_t, std::vector<size_t>> _sdfBezierMap;
+
+    // material Id -> list of triangle meshes for this morphology
+    size_t _triangleIndx;
+    bool _hasMesh {false};
+
+    // material Id -> list of geometry sdfs for this morphology
+    std::unordered_map<size_t, std::vector<size_t>> _sdfGeometryMap;
+};
+
+#endif

--- a/plugins/CircuitExplorer/plugin/api/MorphologyMap.h
+++ b/plugins/CircuitExplorer/plugin/api/MorphologyMap.h
@@ -22,12 +22,12 @@
 #ifndef MORPHOLOGYMAP_H
 #define MORPHOLOGYMAP_H
 
-#include <brayns/common/geometry/Sphere.h>
-#include <brayns/common/geometry/Cylinder.h>
 #include <brayns/common/geometry/Cone.h>
+#include <brayns/common/geometry/Cylinder.h>
 #include <brayns/common/geometry/SDFBezier.h>
-#include <brayns/common/geometry/TriangleMesh.h>
 #include <brayns/common/geometry/SDFGeometry.h>
+#include <brayns/common/geometry/Sphere.h>
+#include <brayns/common/geometry/TriangleMesh.h>
 #include <brayns/common/types.h>
 
 #include <unordered_map>

--- a/plugins/CircuitExplorer/plugin/io/AdvancedCircuitLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/AdvancedCircuitLoader.cpp
@@ -28,9 +28,10 @@ const std::string LOADER_NAME = "Advanced circuit loader (Experimental)";
 AdvancedCircuitLoader::AdvancedCircuitLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams,
+    CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/AdvancedCircuitLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/AdvancedCircuitLoader.h
@@ -30,7 +30,8 @@ public:
     AdvancedCircuitLoader(
         brayns::Scene &scene,
         const brayns::ApplicationParameters &applicationParameters,
-        brayns::PropertyMap &&loaderParams);
+        brayns::PropertyMap &&loaderParams,
+        CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 

--- a/plugins/CircuitExplorer/plugin/io/AstrocyteLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/AstrocyteLoader.cpp
@@ -34,9 +34,9 @@ const std::string SUPPORTED_EXTENTION_ASTROCYTES = "astrocytes";
 AstrocyteLoader::AstrocyteLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams, CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/AstrocyteLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/AstrocyteLoader.h
@@ -29,7 +29,8 @@ class AstrocyteLoader : public AbstractCircuitLoader
 public:
     AstrocyteLoader(brayns::Scene &scene,
                     const brayns::ApplicationParameters &applicationParameters,
-                    brayns::PropertyMap &&loaderParams);
+                    brayns::PropertyMap &&loaderParams,
+                    CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 

--- a/plugins/CircuitExplorer/plugin/io/MeshCircuitLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/MeshCircuitLoader.cpp
@@ -29,9 +29,9 @@ const double DEFAULT_RADIUS_MULTIPLIER = 2.0;
 MeshCircuitLoader::MeshCircuitLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams, CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/MeshCircuitLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/MeshCircuitLoader.h
@@ -30,7 +30,8 @@ public:
     MeshCircuitLoader(
         brayns::Scene &scene,
         const brayns::ApplicationParameters &applicationParameters,
-        brayns::PropertyMap &&loaderParams);
+        brayns::PropertyMap &&loaderParams,
+        CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 

--- a/plugins/CircuitExplorer/plugin/io/MorphologyCollageLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/MorphologyCollageLoader.cpp
@@ -28,9 +28,9 @@ const std::string LOADER_NAME = "Morphology collage use-case";
 MorphologyCollageLoader::MorphologyCollageLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams, CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/MorphologyCollageLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/MorphologyCollageLoader.h
@@ -30,7 +30,8 @@ public:
     MorphologyCollageLoader(
         brayns::Scene &scene,
         const brayns::ApplicationParameters &applicationParameters,
-        brayns::PropertyMap &&loaderParams);
+        brayns::PropertyMap &&loaderParams,
+        CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 

--- a/plugins/CircuitExplorer/plugin/io/PairSynapsesLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/PairSynapsesLoader.cpp
@@ -28,9 +28,9 @@ const std::string LOADER_NAME = "Pair synapses use-case";
 PairSynapsesLoader::PairSynapsesLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams, CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/PairSynapsesLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/PairSynapsesLoader.h
@@ -27,7 +27,8 @@ public:
     PairSynapsesLoader(
         brayns::Scene &scene,
         const brayns::ApplicationParameters &applicationParameters,
-        brayns::PropertyMap &&loaderParams);
+        brayns::PropertyMap &&loaderParams,
+        CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 

--- a/plugins/CircuitExplorer/plugin/io/SynapseCircuitLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/SynapseCircuitLoader.cpp
@@ -28,9 +28,9 @@ const std::string LOADER_NAME = "Synapse loader use-case";
 SynapseCircuitLoader::SynapseCircuitLoader(
     brayns::Scene &scene,
     const brayns::ApplicationParameters &applicationParameters,
-    brayns::PropertyMap &&loaderParams)
+    brayns::PropertyMap &&loaderParams, CircuitExplorerPlugin* plugin)
     : AbstractCircuitLoader(scene, applicationParameters,
-                            std::move(loaderParams))
+                            std::move(loaderParams), plugin)
 {
     PLUGIN_INFO << "Registering " << LOADER_NAME << std::endl;
     _fixedDefaults.setProperty(

--- a/plugins/CircuitExplorer/plugin/io/SynapseCircuitLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/SynapseCircuitLoader.h
@@ -30,7 +30,8 @@ public:
     SynapseCircuitLoader(
         brayns::Scene &scene,
         const brayns::ApplicationParameters &applicationParameters,
-        brayns::PropertyMap &&loaderParams);
+        brayns::PropertyMap &&loaderParams,
+        CircuitExplorerPlugin* plugin);
 
     std::string getName() const final;
 


### PR DESCRIPTION
- Added support to remap circuit color to a different scheme on the fly
- Meshes and circuit (for some schemes) metadata contains now material information
- OSPRay engine SDF rendering minor optimizations
- CMake fixes to import HighFive target when duplicated
- Fixed snapshot utility to generate images with simulation data
- Bumped Brion version to lastest (now with support for new sonata readers)
- Updated CMake/common submodule to fix recursive clonning