### PR TITLE
Miscelaneus engine fixes:

### DIFF
--- a/brayns/common/geometry/TriangleMesh.h
+++ b/brayns/common/geometry/TriangleMesh.h
@@ -47,10 +47,10 @@ inline TriangleMesh createBox(const Vector3f& minCorner, const Vector3f& maxCorn
     result.vertices.emplace_back(maxCorner);
     result.vertices.emplace_back(minCorner.x, minCorner.y, maxCorner.z);
     result.vertices.emplace_back(maxCorner.x, minCorner.y, maxCorner.z);
-    result.normals.emplace_back(0.f, 0.f, -1.f);
-    result.normals.emplace_back(0.f, 0.f, -1.f);
-    result.normals.emplace_back(0.f, 0.f, -1.f);
-    result.normals.emplace_back(0.f, 0.f, -1.f);
+    result.normals.emplace_back(0.f, 0.f, 1.f);
+    result.normals.emplace_back(0.f, 0.f, 1.f);
+    result.normals.emplace_back(0.f, 0.f, 1.f);
+    result.normals.emplace_back(0.f, 0.f, 1.f);
     result.indices.emplace_back(0, 2, 1);
     result.indices.emplace_back(1, 2, 3);
     // Back face
@@ -58,10 +58,10 @@ inline TriangleMesh createBox(const Vector3f& minCorner, const Vector3f& maxCorn
     result.vertices.emplace_back(maxCorner.x, maxCorner.y, minCorner.z);
     result.vertices.emplace_back(minCorner);
     result.vertices.emplace_back(maxCorner.x, minCorner.y, minCorner.z);
-    result.normals.emplace_back(0.f, 0.f, 1.f);
-    result.normals.emplace_back(0.f, 0.f, 1.f);
-    result.normals.emplace_back(0.f, 0.f, 1.f);
-    result.normals.emplace_back(0.f, 0.f, 1.f);
+    result.normals.emplace_back(0.f, 0.f, -1.f);
+    result.normals.emplace_back(0.f, 0.f, -1.f);
+    result.normals.emplace_back(0.f, 0.f, -1.f);
+    result.normals.emplace_back(0.f, 0.f, -1.f);
     result.indices.emplace_back(4, 6, 5);
     result.indices.emplace_back(5, 6, 7);
     // Left face

--- a/engines/pbrt/PBRTMaterial.cpp
+++ b/engines/pbrt/PBRTMaterial.cpp
@@ -820,7 +820,7 @@ void PBRTMaterial::commit(const std::string& renderer)
     _renderer = renderer;
 
     // If we cannot commit it, it will result on a crash
-    auto matClass = PBRTMaterialClass::MATERIAL_PLASTIC;
+    auto matClass = PBRTMaterialClass::MATERIAL_MATTE;
     if(hasProperty("materialClass"))
         matClass = static_cast<PBRTMaterialClass>
                                 (getProperty<int>("materialClass"));
@@ -836,9 +836,9 @@ void PBRTMaterial::commit(const std::string& renderer)
     {
         BRAYNS_WARN << "PBRT: material " << materialClassToString(matClass)
                     << " unsupported for integrator "
-                    << _renderer << ", switching to plastic" << std::endl;
+                    << _renderer << ", switching to matte" << std::endl;
 
-        matClass = PBRTMaterialClass::MATERIAL_PLASTIC;
+        matClass = PBRTMaterialClass::MATERIAL_MATTE;
     }
 
     pbrt::Material* rawMat = _instantiateMaterial(matClass);

--- a/engines/pbrt/PBRTModel.h
+++ b/engines/pbrt/PBRTModel.h
@@ -95,7 +95,6 @@ private:
     static std::unordered_map<std::string, MediaFactory> _mediaFactories;
     // Media object
     std::shared_ptr<pbrt::Medium> _modelMedium {nullptr};
-    size_t _mediumMatId;
 
     // Model global transforms
     pbrt::Transform _objectToWorld;

--- a/engines/pbrtv2/PBRTMaterial.cpp
+++ b/engines/pbrtv2/PBRTMaterial.cpp
@@ -719,7 +719,7 @@ pbrt::Material* PBRTMaterial::_instantiateMaterial(const PBRTMaterialClass matCl
 void PBRTMaterial::commit()
 {
     // If we cannot commit it, it will result on a crash
-    auto matClass = PBRTMaterialClass::MATERIAL_PLASTIC;
+    auto matClass = PBRTMaterialClass::MATERIAL_MATTE;
     if(hasProperty("materialClass"))
         matClass = static_cast<PBRTMaterialClass>
                                 (getProperty<int>("materialClass"));

--- a/engines/pbrtv2/PBRTModel.cpp
+++ b/engines/pbrtv2/PBRTModel.cpp
@@ -59,7 +59,7 @@ pbrt::VolumeRegion* HomogeneusVolumeFactory(pbrt::Transform* otw, const Property
     const auto g = static_cast<float>(meta.getProperty<double>("g", 0.0));
     const auto sigADArr = meta.getProperty<std::array<double, 3>>("sig_a",
                                                                   {.0011f, .0024f, .014f});
-    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_a",
+    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_s",
                                                                   {2.55f, 3.21f, 3.77f});
     const auto density = static_cast<float>(meta.getProperty<double>("density", 1.0));
     const auto LeDArr = meta.getProperty<std::array<double, 3>>("Le", {1., 1., 1.});
@@ -95,7 +95,7 @@ pbrt::VolumeRegion* HeterogeneusVolumeFactory(pbrt::Transform* otw, const Proper
     const auto g = static_cast<float>(meta.getProperty<double>("g", 0.0));
     const auto sigADArr = meta.getProperty<std::array<double, 3>>("sig_a",
                                                                   {.0011f, .0024f, .014f});
-    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_a",
+    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_s",
                                                                   {2.55f, 3.21f, 3.77f});
     const auto minDensity = static_cast<float>(meta.getProperty<double>("min_density", 0.0));
     const auto maxDensity = static_cast<float>(meta.getProperty<double>("max_density", 1.0));
@@ -132,7 +132,7 @@ pbrt::VolumeRegion* GridVolumeFactory(pbrt::Transform* otw, const PropertyMap& m
     const auto g = static_cast<float>(meta.getProperty<double>("g", 0.0));
     const auto sigADArr = meta.getProperty<std::array<double, 3>>("sig_a",
                                                                   {.0011f, .0024f, .014f});
-    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_a",
+    const auto sigSDArr = meta.getProperty<std::array<double, 3>>("sig_s",
                                                                   {2.55f, 3.21f, 3.77f});
     const auto density = meta.getProperty<std::vector<float>>("density", std::vector<float>());
     const auto nx = meta.getProperty<int>("nx", 0);

--- a/plugins/PBRVolumes/PBRVolumesPlugin.cpp
+++ b/plugins/PBRVolumes/PBRVolumesPlugin.cpp
@@ -109,12 +109,11 @@ inline void addCommonParams(const Request& req, brayns::PropertyMap& metaObject)
 }
 
 template<typename Request>
-inline void addBoxParams(const Request& req, brayns::PropertyMap& metaObject)
+inline void createBoxMesh(const Request& req, brayns::Model& model)
 {
-    const std::array<double, 3> p0 = {req.p0[0], req.p0[1], req.p0[2]};
-    metaObject.setProperty({"p0", p0});
-    const std::array<double, 3> p1 = {req.p1[0], req.p1[1], req.p1[2]};
-    metaObject.setProperty({"p1", p1});
+    const brayns::Vector3f min (req.p0[0], req.p0[1], req.p0[2]);
+    const brayns::Vector3f max (req.p1[0], req.p1[1], req.p1[2]);
+    model.getTriangleMeshes()[brayns::NO_MATERIAL] = brayns::createBox(min, max);
 }
 
 PBRVolumesPlugin::PBRVolumesPlugin()
@@ -176,9 +175,11 @@ AddVolumeResponse PBRVolumesPlugin::_addHomogeneusVolume(const AddHomogeneusVolu
     metaObject.setProperty({"volume_type", std::string("homogeneus")});
     metaObject.setProperty({"density", static_cast<double>(req.density)});
     addCommonParams(req, metaObject);
-    addBoxParams(req, metaObject);
 
     auto modelPtr = _api->getScene().createModel();
+
+    createBoxMesh(req, *modelPtr);
+
     modelPtr->addMetaObject(brayns::NO_MATERIAL, metaObject);
     const std::string name = req.name.empty()? "Volume" : req.name;
     _api->getScene().addModel(std::make_shared<brayns::ModelDescriptor>(std::move(modelPtr),
@@ -243,9 +244,11 @@ AddVolumeResponse PBRVolumesPlugin::_addHeterogeneusVolume(const AddHeterogeneus
     metaObject.setProperty({"min_density", static_cast<double>(req.minDensity)});
     metaObject.setProperty({"max_density", static_cast<double>(req.maxDensity)});
     addCommonParams(req, metaObject);
-    addBoxParams(req, metaObject);
 
     auto modelPtr = _api->getScene().createModel();
+
+    createBoxMesh(req, *modelPtr);
+
     modelPtr->addMetaObject(brayns::NO_MATERIAL, metaObject);
     const std::string name = req.name.empty()? "Volume" : req.name;
     _api->getScene().addModel(std::make_shared<brayns::ModelDescriptor>(std::move(modelPtr),
@@ -294,9 +297,11 @@ AddVolumeResponse PBRVolumesPlugin::_addGridVolume(const AddGridVolume& req)
     metaObject.setProperty({"ny", req.ny});
     metaObject.setProperty({"nz", req.nz});
     addCommonParams(req, metaObject);
-    addBoxParams(req, metaObject);
 
     auto modelPtr = _api->getScene().createModel();
+
+    createBoxMesh(req, *modelPtr);
+
     modelPtr->addMetaObject(brayns::NO_MATERIAL, metaObject);
     const std::string name = req.name.empty()? "Volume" : req.name;
     _api->getScene().addModel(std::make_shared<brayns::ModelDescriptor>(std::move(modelPtr),

--- a/python/brayns/plugins/pbr_volumes.py
+++ b/python/brayns/plugins/pbr_volumes.py
@@ -53,8 +53,8 @@ class PBRVolumes:
         """
         params = dict()
         params["name"] = name
-        params["absorption"] = sig_s
-        params["scattering"] = sig_a
+        params["absorption"] = sig_a
+        params["scattering"] = sig_s
         params["scale"] = scale
         params["g"] = g
         params["Le"] = Le
@@ -84,8 +84,8 @@ class PBRVolumes:
         """
         params = dict()
         params["name"] = name
-        params["absorption"] = sig_s
-        params["scattering"] = sig_a
+        params["absorption"] = sig_a
+        params["scattering"] = sig_s
         params["scale"] = scale
         params["g"] = g
         params["Le"] = Le
@@ -116,8 +116,8 @@ class PBRVolumes:
         """
         params = dict()
         params["name"] = name
-        params["absorption"] = sig_s
-        params["scattering"] = sig_a
+        params["absorption"] = sig_a
+        params["scattering"] = sig_s
         params["scale"] = scale
         params["g"] = g
         params["Le"] = Le
@@ -154,8 +154,8 @@ class PBRVolumes:
         """
         params = dict()
         params["name"] = name
-        params["absorption"] = sig_s
-        params["scattering"] = sig_a
+        params["absorption"] = sig_a
+        params["scattering"] = sig_s
         params["scale"] = scale
         params["g"] = g
         params["Le"] = Le


### PR DESCRIPTION
- Fix procedural box mesh normals
- Default material for both pbrt engines is matte instead of plastic
- Fix wrong parameter acquisition for volume generation