### PR TITLE
Small fixes for DTI plugin and export-frames-to-disk

### DIFF
--- a/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.cpp
+++ b/plugins/CircuitExplorer/plugin/CircuitExplorerPlugin.cpp
@@ -1736,9 +1736,11 @@ void CircuitExplorerPlugin::_doExportFrameToDisk()
     DWORD numPixels = 0;
     FreeImage_AcquireMemory(memory.get(), &pixels, &numPixels);
 
+    auto fn = _frameNumber;
+    if(_exportFramesToDiskPayload.nameAfterStep)
+        fn = _exportFramesToDiskPayload.animationInformation[_frameNumber];
     char frame[7];
-    sprintf(frame, "%05d",
-            static_cast<int32_t>(_exportFramesToDiskPayload.animationInformation[_frameNumber]));
+    sprintf(frame, "%05d", static_cast<int32_t>(fn));
 
     std::string filename = _exportFramesToDiskPayload.path + '/' + frame + "." +
                            _exportFramesToDiskPayload.format;

--- a/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.h
+++ b/plugins/CircuitExplorer/plugin/api/CircuitExplorerParams.h
@@ -324,6 +324,7 @@ struct ExportFramesToDisk : public brayns::Message
     MESSAGE_BEGIN(ExportFramesToDisk)
     MESSAGE_ENTRY(std::string, path, "Path to the directory where the frames will be saved")
     MESSAGE_ENTRY(std::string, format, "The image format (PNG or JPEG)")
+    MESSAGE_ENTRY(bool, nameAfterStep, "Name the file on disk after the simulation step index")
     MESSAGE_ENTRY(uint32_t, quality, "The quality at which the images will be stored")
     MESSAGE_ENTRY(uint32_t, spp,
                   "Samples per pixels (The more, the better visual result and the slower the"

--- a/plugins/DTI/DTIPlugin.cpp
+++ b/plugins/DTI/DTIPlugin.cpp
@@ -294,7 +294,7 @@ void DTIPlugin::_updateSpikeSimulationFromFile(const SpikeSimulationFromFile& sr
     }
 
     _spikeSimulation.dt = src.dt;
-    _spikeSimulation.endTime = spikeReport->getEndTime() + src.decaySpeed;
+    _spikeSimulation.endTime = spikeReport->getEndTime();
     _spikeSimulation.modelId = src.modelId;
     _spikeSimulation.timeScale = src.timeScale;
     _spikeSimulation.decaySpeed = src.decaySpeed;

--- a/python/brayns/plugins/circuit_explorer.py
+++ b/python/brayns/plugins/circuit_explorer.py
@@ -504,7 +504,7 @@ class CircuitExplorer:
                                     response_timeout=self.DEFAULT_RESPONSE_TIMEOUT)
 
     def export_frames_to_disk(self, path, animation_frames, camera_definitions, image_format='png',
-                              quality=100, samples_per_pixel=1, start_frame=0):
+                              quality=100, samples_per_pixel=1, start_frame=0, name_after_step=False):
         """
         Exports frames to disk. Frames are named using a 6 digit representation of the frame number
 
@@ -515,6 +515,7 @@ class CircuitExplorer:
         :param float quality: Quality of the exported image (Between 0 and 100)
         :param int samples_per_pixel: Number of samples per pixels
         :param int start_frame: Optional value if the rendering should start at a specific frame.
+        :param bool name_after_step: Name the file on disk after the simulation step index.
         This is used to resume the rendering of a previously canceled sequence)
         :return: Result of the request submission
         :rtype: str
@@ -522,6 +523,7 @@ class CircuitExplorer:
         params = dict()
         params['path'] = path
         params['format'] = image_format
+        params['nameAfterStep'] = name_after_step
         params['quality'] = quality
         params['spp'] = samples_per_pixel
         params['startFrame'] = start_frame

--- a/python/doc/source/api_circuitexplorer_methods.rst
+++ b/python/doc/source/api_circuitexplorer_methods.rst
@@ -315,6 +315,7 @@ Parameters:
 * ``quality``: ``integer``, The quality at which the images will be stored
 * ``spp``: ``integer``, Samples per pixels (The more, the better visual result and the slower the rendering)
 * ``start_frame``: ``integer``, The frame at which to start exporting frames
+* ``name_after_step``: ``bool``, Name the file on disk after the simulation step index.
 
 Error:
 

--- a/python/doc/source/api_circuitexplorer_module.rst
+++ b/python/doc/source/api_circuitexplorer_module.rst
@@ -291,6 +291,7 @@ Parameters:
 * ``quality``: ``float``,  Quality of the exported image (Between 0 and 100).
 * ``samples_per_pixel``: ``int``,  Number of samples per pixels.
 * ``start_frame``: ``int``,  Optional value if the rendering should start at a specific frame.
+* ``name_after_step``: ``bool``, Name the file on disk after the simulation step index.
 
 Error:
 


### PR DESCRIPTION
- Fixes computation of end time for spike reports loaded from disk
- Add file naming options for frames export to disk