### PR TITLE
Allow to build with GCC 11.

### DIFF
--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -57,7 +57,7 @@
 
 #include <brayns/pluginapi/PluginAPI.h>
 
-#include <mutex>  // std::unique_lock
+#include <mutex> // std::unique_lock
 #include <thread>
 
 namespace

--- a/brayns/Brayns.cpp
+++ b/brayns/Brayns.cpp
@@ -57,6 +57,7 @@
 
 #include <brayns/pluginapi/PluginAPI.h>
 
+#include <mutex>  // std::unique_lock
 #include <thread>
 
 namespace

--- a/brayns/engine/Scene.cpp
+++ b/brayns/engine/Scene.cpp
@@ -34,7 +34,7 @@
 #include <brayns/common/utils/filesystem.h>
 
 #include <fstream>
-#include <mutex>  // std::unique_lock
+#include <mutex> // std::unique_lock
 
 namespace
 {

--- a/brayns/engine/Scene.cpp
+++ b/brayns/engine/Scene.cpp
@@ -34,6 +34,7 @@
 #include <brayns/common/utils/filesystem.h>
 
 #include <fstream>
+#include <mutex>  // std::unique_lock
 
 namespace
 {

--- a/brayns/network/adapters/PropertyMapAdapter.h
+++ b/brayns/network/adapters/PropertyMapAdapter.h
@@ -153,6 +153,10 @@ private:
     }
 };
 
+#ifdef _serialize
+#undef _serialize
+#endif
+
 class PropertyMapSerializer
 {
 public:


### PR DESCRIPTION
It seems that GCC has gotten a bit more pedantic about header inclusion,
and thus more parts of std:: have to be included directly.

Also deletes a new macro that interferes, and does not follow the
reserved namescheme.

Still has to be compiled with -Wno-error=range-loop-construct.
