### PR TITLE
Improves circuit loading:

### DIFF
--- a/plugins/CircuitExplorer/plugin/io/BBPLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/BBPLoader.cpp
@@ -78,7 +78,7 @@ brain::GIDSet
     if (!input.targets.empty())
         targets = input.targets;
     else if (const auto defaultTarget = config.getCircuitTarget(); !defaultTarget.empty())
-        targets = {config.getCircuitTarget()};
+        targets = {defaultTarget};
 
     brain::GIDSet allGids;
     if (!targets.empty())

--- a/plugins/CircuitExplorer/plugin/io/BBPLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/BBPLoader.cpp
@@ -77,15 +77,20 @@ brain::GIDSet
     std::vector<std::string> targets;
     if (!input.targets.empty())
         targets = input.targets;
-    else
+    else if (const auto defaultTarget = config.getCircuitTarget(); !defaultTarget.empty())
         targets = {config.getCircuitTarget()};
 
     brain::GIDSet allGids;
-    for (const auto &target : targets)
+    if (!targets.empty())
     {
-        const auto tempGids = circuit.getGIDs(target);
-        allGids.insert(tempGids.begin(), tempGids.end());
+        for (const auto &target : targets)
+        {
+            const auto tempGids = circuit.getGIDs(target);
+            allGids.insert(tempGids.begin(), tempGids.end());
+        }
     }
+    else
+        allGids = circuit.getGIDs();
 
     if (input.percentage >= 1.f)
         return allGids;

--- a/plugins/CircuitExplorer/plugin/io/bbploader/CellLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/bbploader/CellLoader.cpp
@@ -69,10 +69,12 @@ std::vector<MorphologyInstance::Ptr>
     for (const auto &entry : morphPathMap)
         loadTasks.push_back(std::async(loadFn, entry.first, entry.second));
 
-    for (const auto &task : loadTasks)
+    for (auto &task : loadTasks)
     {
         if (task.valid())
-            task.wait();
+            task.get();
+        else
+            throw std::runtime_error("Unknown error while loading morphologies");
     }
 
     return cells;

--- a/plugins/CircuitExplorer/plugin/io/bbploader/ParameterCheck.cpp
+++ b/plugins/CircuitExplorer/plugin/io/bbploader/ParameterCheck.cpp
@@ -43,7 +43,7 @@ void checkTargets(const brion::BlueConfig &config, const BBPLoaderParameters &in
     for (const auto &trg : input.targets)
     {
         if (trg.empty())
-            continue;
+            throw std::invalid_argument("BBPLoader: Specified an empty target name");
 
         bool exists = false;
         for (const auto &parser : targetParsers)

--- a/plugins/CircuitExplorer/plugin/io/bbploader/ParameterCheck.cpp
+++ b/plugins/CircuitExplorer/plugin/io/bbploader/ParameterCheck.cpp
@@ -42,6 +42,9 @@ void checkTargets(const brion::BlueConfig &config, const BBPLoaderParameters &in
     const auto targetParsers = config.getTargets();
     for (const auto &trg : input.targets)
     {
+        if (trg.empty())
+            continue;
+
         bool exists = false;
         for (const auto &parser : targetParsers)
         {

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
@@ -81,7 +81,9 @@ std::vector<MorphologyInstance::Ptr> CommonNodeLoader::loadNodes(
     for (const auto &task : loadTasks)
     {
         if (task.valid())
-            task.wait();
+            task.get();
+        else
+            throw std::runtime_error("Unknown error while loading morphologies");
     }
 
     return result;

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
@@ -78,7 +78,7 @@ std::vector<MorphologyInstance::Ptr> CommonNodeLoader::loadNodes(
     for (const auto &entry : morphologyMap)
         loadTasks.push_back(std::async(loadFn, entry.first, entry.second));
 
-    for (const auto &task : loadTasks)
+    for (auto &task : loadTasks)
     {
         if (task.valid())
             task.get();


### PR DESCRIPTION
- Allows for CircuitConfig/BlueConfig without CircuitTarget entry (will use instead all circuit cells)
- Replaced morphology load future handling from wait() to get() to propagate any exception during loading
- Make sure to throw an exception if a future does not have a correct shared state before getting it