### PR TITLE
SONATA loader update

### DIFF
--- a/plugins/CircuitExplorer/plugin/io/SonataLoaderParameters.h
+++ b/plugins/CircuitExplorer/plugin/io/SonataLoaderParameters.h
@@ -47,8 +47,7 @@ BRAYNS_JSON_OBJECT_BEGIN(VasculatureGeometrySettings)
 BRAYNS_JSON_OBJECT_ENTRY(
     float,
     radius_multiplier,
-    "Factor by which to multiply all vasculature sample "
-    "radii. Ignored if radius_override is greater than 0",
+    "Factor by which to multiply all vasculature sample radii. Ignored if radius_override is greater than 0",
     brayns::Default(1.f))
 BRAYNS_JSON_OBJECT_ENTRY(
     float,
@@ -64,8 +63,8 @@ BRAYNS_JSON_OBJECT_ENTRY(bool, load_afferent, "Wether to load afferent or effere
 BRAYNS_JSON_OBJECT_ENTRY(float, edge_percentage, "Percentage of edges to load from all available")
 BRAYNS_JSON_OBJECT_ENTRY(
     std::string,
-    edge_report,
-    "Path to a synapse report to load algon the edge population",
+    edge_report_name,
+    "Name of a synapse report to load along the edge population",
     brayns::Required(false))
 BRAYNS_JSON_OBJECT_END()
 
@@ -76,8 +75,7 @@ BRAYNS_JSON_OBJECT_ENTRY(std::string, node_population, "Name of the node populat
 BRAYNS_JSON_OBJECT_ENTRY(
     std::vector<std::string>,
     node_sets,
-    "List of node set names/regex to filter the node population load. Ignored "
-    "if a list of node ids is provided",
+    "List of node set names/regex to filter the node population load. Ignored if a list of node ids is provided",
     brayns::Required(false))
 BRAYNS_JSON_OBJECT_ENTRY(
     float,
@@ -87,20 +85,17 @@ BRAYNS_JSON_OBJECT_ENTRY(
 BRAYNS_JSON_OBJECT_ENTRY(
     std::vector<uint64_t>,
     node_ids,
-    "List of node IDs to load from the population. "
-    "Invalidates 'node_percentage' and 'node_sets'",
+    "List of node IDs to load from the population. Invalidates 'node_percentage' and 'node_sets'",
     brayns::Required(false))
 BRAYNS_JSON_OBJECT_ENTRY(
     sonataloader::ReportType,
     report_type,
-    "Type of report to load for the given node population. Possible values "
-    "are: "
+    "Type of report to load for the given node population. Possible values are: "
         + string_utils::join(brayns::enumNames<sonataloader::ReportType>(), ", "))
 BRAYNS_JSON_OBJECT_ENTRY(
     std::string,
-    report_path,
-    "Path of the report file to load (Ignored if report_type "
-    "is 'none' or 'spikes')",
+    report_name,
+    "Name of the report file to load (Ignored if report_type is 'none' or 'spikes')",
     brayns::Required(false))
 BRAYNS_JSON_OBJECT_ENTRY(
     std::vector<SonataEdgePopulationParameters>,
@@ -110,18 +105,24 @@ BRAYNS_JSON_OBJECT_ENTRY(
 BRAYNS_JSON_OBJECT_ENTRY(
     NeuronMorphologyLoaderParameters,
     neuron_morphology_parameters,
-    "Settings to configure the morphology geometry load. "
-    "Ignored for vasculature populations")
+    "Settings to configure the morphology geometry load. Ignored for vasculature populations",
+    Required(false))
 BRAYNS_JSON_OBJECT_ENTRY(
     VasculatureGeometrySettings,
     vasculature_geometry_parameters,
-    "Settings to configure the vasculature geometry load. "
-    "Ignored for any node population that is not vasculature")
+    "Settings to configure the vasculature geometry load. Ignored for any node population that is not vasculature",
+    Required(false))
 BRAYNS_JSON_OBJECT_END()
 
 // ---------------------------------------------------------------------------
 
 BRAYNS_JSON_OBJECT_BEGIN(SonataLoaderParameters)
+BRAYNS_JSON_OBJECT_ENTRY(
+    std::string,
+    simulation_config_path,
+    "Path to the simulation config file .json "
+    "(By default will be searched in the same directory as the circuit config with name simulation_config.json)",
+    Required(false))
 BRAYNS_JSON_OBJECT_ENTRY(
     std::vector<SonataNodePopulationParameters>,
     node_population_settings,

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/ParameterCheck.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/ParameterCheck.h
@@ -19,8 +19,7 @@
 #pragma once
 
 #include <plugin/io/SonataLoaderParameters.h>
-
-#include <bbp/sonata/config.h>
+#include <plugin/io/sonataloader/data/SonataConfig.h>
 
 namespace sonataloader
 {
@@ -31,6 +30,6 @@ public:
      * @brief checks the user input parameters that configures the circuit load
      * @throws std::invalid_argument if any parameter is wrong
      */
-    static void checkInput(const bbp::sonata::CircuitConfig &config, const SonataLoaderParameters &input);
+    static void checkInput(const SonataNetworkConfig &network, const SonataLoaderParameters &input);
 };
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/PopulationColorManager.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/PopulationColorManager.cpp
@@ -31,13 +31,15 @@
 namespace sonataloader
 {
 CircuitColorHandler::Ptr PopulationColorManager::createNodeColorHandler(
-    const SonataConfig::Data &network,
+    const SonataNetworkConfig &network,
     const SonataNodePopulationParameters &lc)
 {
     std::string type;
+    const auto &config = network.circuitConfig();
+    const auto &populationName = lc.node_population;
     try
     {
-        const auto population = network.config.getNodePopulation(lc.node_population);
+        const auto population = config.getNodePopulation(populationName);
         type = SonataCells::getPopulationType(population);
     }
     catch (...)
@@ -46,24 +48,27 @@ CircuitColorHandler::Ptr PopulationColorManager::createNodeColorHandler(
             "[CE] PopulationLoaderManager: Extracting population type "
             "from population properties for {}.",
             lc.node_population);
-        type = network.config.getNodePopulationProperties(lc.node_population).type;
+        type = config.getNodePopulationProperties(populationName).type;
     }
 
     if (type == "vasculature")
         return std::make_unique<VasculatureColorHandler>();
 
-    return std::make_unique<SonataNeuronColorHandler>(network.path, lc.node_population);
+    return std::make_unique<SonataNeuronColorHandler>(config, lc.node_population);
 }
 
 CircuitColorHandler::Ptr PopulationColorManager::createEdgeColorHandler(
-    const SonataConfig::Data &network,
+    const SonataNetworkConfig &network,
     const SonataEdgePopulationParameters &lc)
 {
-    const auto edgeProperties = network.config.getEdgePopulationProperties(lc.edge_population);
+    const auto &config = network.circuitConfig();
+    const auto &population = lc.edge_population;
+    const auto edgeProperties = config.getEdgePopulationProperties(population);
+    const auto loadAfferent = lc.load_afferent;
 
     if (edgeProperties.type == "endfoot")
         return std::make_unique<EndFootColorHandler>();
 
-    return std::make_unique<CommonEdgeColorHandler>(network.path, lc.edge_population, lc.load_afferent);
+    return std::make_unique<CommonEdgeColorHandler>(config, population, loadAfferent);
 }
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/PopulationColorManager.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/PopulationColorManager.h
@@ -36,14 +36,14 @@ public:
      * @brief creates a CircuitColorHandler based on the node population type
      */
     static CircuitColorHandler::Ptr createNodeColorHandler(
-        const SonataConfig::Data &network,
+        const SonataNetworkConfig &network,
         const SonataNodePopulationParameters &lc);
 
     /**
      * @brief creates a CircuitColorHandler based on the edge population type
      */
     static CircuitColorHandler::Ptr createEdgeColorHandler(
-        const SonataConfig::Data &network,
+        const SonataNetworkConfig &network,
         const SonataEdgePopulationParameters &lc);
 };
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/edge/CommonEdgeColorHandler.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/edge/CommonEdgeColorHandler.cpp
@@ -113,10 +113,10 @@ std::vector<std::string> getMethodsValues(
 } // namespace
 
 CommonEdgeColorHandler::CommonEdgeColorHandler(
-    const std::string &configPath,
+    bbp::sonata::CircuitConfig config,
     const std::string &edgePopulation,
     const bool afferent)
-    : _config(bbp::sonata::CircuitConfig::fromFile(configPath))
+    : _config(std::move(config))
     , _edgePopulation(edgePopulation)
     , _nodePopulation(getNodePopulation(_config, _edgePopulation, afferent))
     , _afferent(afferent)

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/edge/CommonEdgeColorHandler.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/edge/CommonEdgeColorHandler.h
@@ -32,7 +32,7 @@ namespace sonataloader
 class CommonEdgeColorHandler : public CircuitColorHandler
 {
 public:
-    CommonEdgeColorHandler(const std::string &configPath, const std::string &edgePopulation, const bool afferent);
+    CommonEdgeColorHandler(bbp::sonata::CircuitConfig config, const std::string &edgePopulation, const bool afferent);
 
     void _setElementsImpl(const std::vector<uint64_t> &ids, std::vector<ElementMaterialMap::Ptr> &&elements) final;
 

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/node/SonataNeuronColorHandler.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/node/SonataNeuronColorHandler.cpp
@@ -59,8 +59,8 @@ std::vector<std::string> getAttributeValues(
 
 namespace sonataloader
 {
-SonataNeuronColorHandler::SonataNeuronColorHandler(const std::string &configPath, const std::string &population)
-    : _config(bbp::sonata::CircuitConfig::fromFile(configPath))
+SonataNeuronColorHandler::SonataNeuronColorHandler(bbp::sonata::CircuitConfig config, const std::string &population)
+    : _config(std::move(config))
     , _population(population)
 {
 }

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/node/SonataNeuronColorHandler.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/colorhandlers/node/SonataNeuronColorHandler.h
@@ -32,7 +32,7 @@ namespace sonataloader
 class SonataNeuronColorHandler : public NeuronColorHandler<std::vector<bbp::sonata::NodeID>>
 {
 public:
-    SonataNeuronColorHandler(const std::string &configPath, const std::string &population);
+    SonataNeuronColorHandler(bbp::sonata::CircuitConfig circuitConfig, const std::string &population);
 
     std::vector<std::string> _getExtraMethods() const final;
     std::vector<std::string> _getValuesForMethod(const std::string &method) const final;

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataConfig.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataConfig.cpp
@@ -16,21 +16,98 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "SonataConfig.h"
+#include <plugin/io/sonataloader/data/SonataConfig.h>
 
-#include <filesystem>
-
-namespace sonataloader
-{
 namespace
 {
 constexpr char H5_FORMAT[] = "h5v1";
 constexpr char ASCII_FORMAT[] = "neurolucida-asc";
+
+std::string getParentDirPath(const std::string &circuitConfigPath)
+{
+    std::filesystem::path base(circuitConfigPath);
+    base = base.parent_path();
+    base = base.lexically_normal();
+    return base.string();
+}
+
+std::optional<bbp::sonata::SimulationConfig> getSimulationConfig(
+    const std::string &circuitConfigDirPath,
+    const std::string &simulationConfigPath)
+{
+    std::filesystem::path simConfigPath(simulationConfigPath);
+    std::filesystem::path configDirPath(circuitConfigDirPath);
+
+    if (std::filesystem::exists(simConfigPath))
+    {
+        return std::optional<bbp::sonata::SimulationConfig>(
+            bbp::sonata::SimulationConfig::fromFile(simulationConfigPath));
+    }
+    else
+    {
+        std::filesystem::path configDirPath(circuitConfigDirPath);
+        if (simConfigPath.is_relative() && std::filesystem::exists(configDirPath / simConfigPath))
+        {
+            const auto composedPath = (configDirPath / simConfigPath).string();
+            return std::optional<bbp::sonata::SimulationConfig>(bbp::sonata::SimulationConfig::fromFile(composedPath));
+        }
+        else if (std::filesystem::exists(configDirPath / std::filesystem::path("simulation_sonata.json")))
+        {
+            const auto composedPath = (configDirPath / std::filesystem::path("simulation_sonata.json")).string();
+            return std::optional<bbp::sonata::SimulationConfig>(bbp::sonata::SimulationConfig::fromFile(composedPath));
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::filesystem::path resolveSimulationBasePath(const bbp::sonata::SimulationConfig &config)
+{
+    const auto &output = config.getOutput();
+
+    std::filesystem::path basePath(output.outputDir);
+    if (!basePath.is_absolute())
+    {
+        const auto &configBasePath = config.getBasePath();
+        basePath = std::filesystem::path(configBasePath) / basePath;
+    }
+
+    return basePath;
+}
 } // namespace
 
-SonataConfig::Data SonataConfig::readNetwork(const std::string &configPath)
+namespace sonataloader
 {
-    return SonataConfig::Data{configPath, bbp::sonata::CircuitConfig::fromFile(configPath)};
+const std::string &SonataNetworkConfig::circuitConfigDir() const noexcept
+{
+    return _circuitConfigDir;
+}
+
+const bbp::sonata::CircuitConfig &SonataNetworkConfig::circuitConfig() const noexcept
+{
+    return _config;
+}
+
+const bbp::sonata::SimulationConfig &SonataNetworkConfig::simulationConfig() const
+{
+    if (!_simConfig.has_value())
+    {
+        throw std::runtime_error("Could not find a simulation configuration file");
+    }
+
+    return _simConfig.value();
+}
+
+SonataNetworkConfig::SonataNetworkConfig(std::string circuitConfigPath, std::string simulationConfigPath)
+    : _circuitConfigDir(getParentDirPath(circuitConfigPath))
+    , _config(bbp::sonata::CircuitConfig::fromFile(circuitConfigPath))
+    , _simConfig(getSimulationConfig(_circuitConfigDir, simulationConfigPath))
+{
+}
+
+SonataNetworkConfig SonataConfig::readNetwork(std::string configPath, std::string simConfigPath)
+{
+    return SonataNetworkConfig(configPath, simConfigPath);
 }
 
 SonataConfig::MorphologyPath::MorphologyPath(const std::string &path, const char *extension)
@@ -58,5 +135,32 @@ SonataConfig::MorphologyPath SonataConfig::resolveMorphologyPath(const bbp::sona
         return SonataConfig::MorphologyPath(ascIt->second, "asc");
 
     throw std::runtime_error("SonataConfig: Could not determine morphology path");
+}
+
+std::filesystem::path SonataConfig::resolveSpikesPath(const bbp::sonata::SimulationConfig &config)
+{
+    auto basePath = resolveSimulationBasePath(config);
+
+    const auto &output = config.getOutput();
+
+    basePath /= std::filesystem::path(output.spikesFile);
+
+    return basePath.lexically_normal();
+}
+
+std::filesystem::path SonataConfig::resolveReportPath(
+    const bbp::sonata::SimulationConfig &config,
+    const std::string &report)
+{
+    if (report.empty())
+    {
+        throw std::invalid_argument("Cannot resolve a report path with an empty report name");
+    }
+
+    auto basePath = resolveSimulationBasePath(config);
+
+    basePath /= std::filesystem::path(report + ".h5");
+
+    return basePath.lexically_normal();
 }
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataConfig.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataConfig.h
@@ -20,18 +20,47 @@
 
 #include <bbp/sonata/config.h>
 
+#include <filesystem>
+#include <optional>
+
 namespace sonataloader
 {
+/**
+ * @brief The SonataNetworkConfig class holds the parsed circuit & simulation configuration files of a SONATA network
+ */
+class SonataNetworkConfig
+{
+public:
+    /**
+     * @brief Returns the path to the folder where circuit config file is located
+     */
+    const std::string &circuitConfigDir() const noexcept;
+
+    /**
+     * @brief Returns the parsed circuit config file
+     */
+    const bbp::sonata::CircuitConfig &circuitConfig() const noexcept;
+
+    /**
+     * @brief Rreturns the parsed simulation config file
+     * @throws std::runtime_error if no simulation configuration file was found while loading
+     */
+    const bbp::sonata::SimulationConfig &simulationConfig() const;
+
+private:
+    friend class SonataConfig;
+
+    SonataNetworkConfig(std::string circuitConfigPath, std::string simulationConfigPath);
+
+    const std::string _circuitConfigDir;
+    const bbp::sonata::CircuitConfig _config;
+    const std::optional<bbp::sonata::SimulationConfig> _simConfig;
+};
+
 class SonataConfig
 {
 public:
-    struct Data
-    {
-        std::string path;
-        bbp::sonata::CircuitConfig config;
-    };
-
-    static Data readNetwork(const std::string &configPath);
+    static SonataNetworkConfig readNetwork(std::string configPath, std::string simConfigPath);
 
     class MorphologyPath
     {
@@ -46,5 +75,11 @@ public:
     };
 
     static MorphologyPath resolveMorphologyPath(const bbp::sonata::PopulationProperties &);
+
+    static std::filesystem::path resolveSpikesPath(const bbp::sonata::SimulationConfig &simConfig);
+
+    static std::filesystem::path resolveReportPath(
+        const bbp::sonata::SimulationConfig &simConfig,
+        const std::string &report);
 };
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSelection.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSelection.cpp
@@ -19,8 +19,8 @@
 #include "SonataSelection.h"
 
 #include <bbp/sonata/node_sets.h>
-#include <bbp/sonata/report_reader.h>
 
+#include <plugin/io/sonataloader/data/SonataConfig.h>
 #include <plugin/io/sonataloader/data/SonataSimulationMapping.h>
 
 namespace sonataloader
@@ -64,7 +64,9 @@ void NodeSelection::select(
         }
     }
     else
+    {
         _nodeSetsSelection = nodePopulation.selectAll();
+    }
 }
 
 void NodeSelection::select(const std::vector<uint64_t> &nodeList)
@@ -72,10 +74,18 @@ void NodeSelection::select(const std::vector<uint64_t> &nodeList)
     _nodeListSelection = bbp::sonata::Selection::fromValues(nodeList);
 }
 
-void NodeSelection::select(const ReportType simType, const std::string &reportPath, const std::string &population)
+void NodeSelection::select(
+    const bbp::sonata::SimulationConfig &config,
+    const ReportType simType,
+    const std::string &reportName,
+    const std::string &population)
 {
     if (simType == ReportType::SPIKES || simType == ReportType::NONE)
+    {
         return;
+    }
+
+    auto reportPath = SonataConfig::resolveReportPath(config, reportName);
 
     auto nodeIds = SonataSimulationMapping::getCompartmentNodes(reportPath, population);
     std::sort(nodeIds.begin(), nodeIds.end());

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSelection.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSelection.h
@@ -52,7 +52,11 @@ public:
      * @brief select node ids from a node population based on reported nodes in
      * a simulation
      */
-    void select(const ReportType simType, const std::string &reportPath, const std::string &population);
+    void select(
+        const bbp::sonata::SimulationConfig &config,
+        const ReportType simType,
+        const std::string &reportName,
+        const std::string &population);
 
     /**
      * @brief return the best selection candidate based on what was selected:

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSimulationMapping.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/data/SonataSimulationMapping.h
@@ -18,6 +18,10 @@
 
 #pragma once
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/EdgePopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/EdgePopulationLoader.h
@@ -32,11 +32,8 @@ namespace sonataloader
 class EdgePopulationLoader
 {
 public:
-    using Ptr = std::unique_ptr<EdgePopulationLoader>;
-
-    template<typename T, typename = std::enable_if_t<std::is_constructible<std::string, T>::value>>
-    EdgePopulationLoader(T &&name)
-        : _typeName(std::forward<T>(name))
+    EdgePopulationLoader(std::string typeName)
+        : _typeName(std::move(typeName))
     {
     }
 
@@ -57,7 +54,7 @@ public:
      * progress to listening clients of the Brayns API
      */
     virtual std::vector<SynapseGroup::Ptr> load(
-        const SonataConfig::Data &networkConfig,
+        const SonataNetworkConfig &networkConfig,
         const SonataEdgePopulationParameters &lc,
         const bbp::sonata::Selection &nodeSelection) const = 0;
 

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/NodePopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/NodePopulationLoader.h
@@ -33,11 +33,8 @@ namespace sonataloader
 class NodePopulationLoader
 {
 public:
-    using Ptr = std::unique_ptr<NodePopulationLoader>;
-
-    template<typename T, typename = std::enable_if_t<std::is_constructible<std::string, T>::value>>
-    NodePopulationLoader(T &&typeName)
-        : _typeName(std::forward<T>(typeName))
+    NodePopulationLoader(std::string populationType)
+        : _typeName(std::move(populationType))
     {
     }
 
@@ -58,7 +55,7 @@ public:
      * progress to listening clients of the Brayns API
      */
     virtual std::vector<MorphologyInstance::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection) const = 0;
 

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/PopulationLoadManager.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/PopulationLoadManager.h
@@ -35,7 +35,7 @@ public:
      * type of edge population denoted by edgeType
      */
     static std::vector<SynapseGroup::Ptr> loadEdges(
-        const SonataConfig::Data &networkConfig,
+        const SonataNetworkConfig &networkConfig,
         const SonataEdgePopulationParameters &lc,
         const bbp::sonata::Selection &nodeSelection);
 
@@ -44,7 +44,7 @@ public:
      * type of node population denoted by nodeType
      */
     static std::vector<MorphologyInstance::Ptr> loadNodes(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection);
 

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/CommonEdgeLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/CommonEdgeLoader.cpp
@@ -25,7 +25,7 @@
 namespace sonataloader
 {
 std::vector<std::unique_ptr<SynapseGroup>> CommonEdgeLoader::load(
-    const SonataConfig::Data &networkConfig,
+    const SonataNetworkConfig &network,
     const SonataEdgePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
@@ -43,12 +43,14 @@ std::vector<std::unique_ptr<SynapseGroup>> CommonEdgeLoader::load(
     std::vector<brayns::Vector3f> surfacePos;
     std::vector<uint64_t> edgeIds;
 
-    const auto population = networkConfig.config.getEdgePopulation(lc.edge_population);
+    const auto &config = network.circuitConfig();
+    const auto &populationName = lc.edge_population;
+    const auto percentage = lc.edge_percentage;
+    const auto population = config.getEdgePopulation(populationName);
 
     if (lc.load_afferent)
     {
-        const auto edgeSelection =
-            EdgeSelection(population.afferentEdges(baseNodeList)).intersection(lc.edge_percentage);
+        const auto edgeSelection = EdgeSelection(population.afferentEdges(baseNodeList)).intersection(percentage);
         edgeIds = edgeSelection.flatten();
         srcNodes = SonataSynapses::getTargetNodes(population, edgeSelection);
         sectionIds = SonataSynapses::getAfferentSectionIds(population, edgeSelection);
@@ -57,8 +59,7 @@ std::vector<std::unique_ptr<SynapseGroup>> CommonEdgeLoader::load(
     }
     else
     {
-        const auto edgeSelection =
-            EdgeSelection(population.efferentEdges(baseNodeList)).intersection(lc.edge_percentage);
+        const auto edgeSelection = EdgeSelection(population.efferentEdges(baseNodeList)).intersection(percentage);
         edgeIds = edgeSelection.flatten();
         srcNodes = SonataSynapses::getSourceNodes(population, edgeSelection);
         surfacePos = SonataSynapses::getEfferentSurfacePos(population, edgeSelection);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/CommonEdgeLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/CommonEdgeLoader.h
@@ -41,7 +41,7 @@ public:
     }
 
     std::vector<SynapseGroup::Ptr> load(
-        const SonataConfig::Data &networkConfig,
+        const SonataNetworkConfig &networkConfig,
         const SonataEdgePopulationParameters &lc,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/EndFootPopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/EndFootPopulationLoader.cpp
@@ -102,20 +102,21 @@ EndFootPopulationLoader::EndFootPopulationLoader()
 }
 
 std::vector<std::unique_ptr<SynapseGroup>> EndFootPopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &network,
     const SonataEdgePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
     if (lc.load_afferent)
         throw std::runtime_error("Afferent edges not supported on endfoot connectivity");
 
-    const auto basePath = std::filesystem::path(networkData.path).parent_path().string();
-    auto path = getEndFeetAreasPath(networkData.config, lc.edge_population, basePath);
-
+    const auto &config = network.circuitConfig();
+    const std::filesystem::path basePath(network.circuitConfigDir());
+    const auto &populationName = lc.edge_population;
+    auto path = getEndFeetAreasPath(config, populationName, basePath);
     const auto nodes = nodeSelection.flatten();
-    const auto population = networkData.config.getEdgePopulation(lc.edge_population);
-
-    const auto edgeSelection = EdgeSelection(population.efferentEdges(nodes)).intersection(lc.edge_percentage);
+    const auto percentage = lc.edge_percentage;
+    const auto population = config.getEdgePopulation(populationName);
+    const auto edgeSelection = EdgeSelection(population.efferentEdges(nodes)).intersection(percentage);
     const auto flatEdges = edgeSelection.flatten();
     const auto sourceNodes = SonataSynapses::getSourceNodes(population, edgeSelection);
     const auto endFeetIds = SonataSynapses::getEndFeetIds(population, edgeSelection);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/EndFootPopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/EndFootPopulationLoader.h
@@ -32,7 +32,7 @@ public:
     EndFootPopulationLoader();
 
     std::vector<SynapseGroup::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataEdgePopulationParameters &lc,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/SynapseAstrocytePopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/SynapseAstrocytePopulationLoader.cpp
@@ -30,7 +30,7 @@ SynapseAstrocytePopulationLoader::SynapseAstrocytePopulationLoader()
 }
 
 std::vector<SynapseGroup::Ptr> SynapseAstrocytePopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &network,
     const SonataEdgePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
@@ -41,15 +41,17 @@ std::vector<SynapseGroup::Ptr> SynapseAstrocytePopulationLoader::load(
             "This should not have happened");
 
     const auto baseNodeList = nodeSelection.flatten();
-
-    const auto population = networkData.config.getEdgePopulation(lc.edge_population);
+    const auto &populationName = lc.edge_population;
+    const auto percentage = lc.edge_percentage;
+    const auto &config = network.circuitConfig();
+    const auto population = config.getEdgePopulation(populationName);
     // Fill it by mapping node ID to synapse list in case there is a node Id
     // without synapses, so we can still place an empty vector at the end
     std::map<uint64_t, std::unique_ptr<SynapseGroup>> mapping;
     for (const auto nodeId : baseNodeList)
         mapping[nodeId] = std::make_unique<SynapseAstrocyteGroup>();
 
-    const auto edgeSelection = EdgeSelection(population.efferentEdges(baseNodeList)).intersection(lc.edge_percentage);
+    const auto edgeSelection = EdgeSelection(population.efferentEdges(baseNodeList)).intersection(percentage);
     const auto edgeIds = edgeSelection.flatten();
     const auto srcNodes = SonataSynapses::getSourceNodes(population, edgeSelection);
     const auto sectionIds = SonataSynapses::getEfferentAstrocyteSectionIds(population, edgeSelection);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/SynapseAstrocytePopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/edges/SynapseAstrocytePopulationLoader.h
@@ -32,7 +32,7 @@ public:
     SynapseAstrocytePopulationLoader();
 
     std::vector<SynapseGroup::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataEdgePopulationParameters &lc,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/AstrocytePopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/AstrocytePopulationLoader.cpp
@@ -28,11 +28,13 @@ AstrocytePopulationLoader::AstrocytePopulationLoader()
 }
 
 std::vector<MorphologyInstance::Ptr> AstrocytePopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &networkData,
     const SonataNodePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
-    const auto population = networkData.config.getNodePopulation(lc.node_population);
+    const auto &populationName = lc.node_population;
+    const auto &config = networkData.circuitConfig();
+    const auto population = config.getNodePopulation(populationName);
     const auto morphologies = SonataCells::getMorphologies(population, nodeSelection);
     const auto positions = SonataCells::getPositions(population, nodeSelection);
     const std::vector<brayns::Quaternion> dummy(positions.size(), brayns::Quaternion());

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/AstrocytePopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/AstrocytePopulationLoader.h
@@ -32,7 +32,7 @@ public:
     AstrocytePopulationLoader();
 
     std::vector<MorphologyInstance::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/BiophysicalPopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/BiophysicalPopulationLoader.cpp
@@ -28,11 +28,13 @@ BiophysicalPopulationLoader::BiophysicalPopulationLoader()
 }
 
 std::vector<MorphologyInstance::Ptr> BiophysicalPopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &networkData,
     const SonataNodePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
-    const auto population = networkData.config.getNodePopulation(lc.node_population);
+    const auto &populationName = lc.node_population;
+    const auto &config = networkData.circuitConfig();
+    const auto population = config.getNodePopulation(populationName);
 
     const auto morphologies = SonataCells::getMorphologies(population, nodeSelection);
     const auto positions = SonataCells::getPositions(population, nodeSelection);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/BiophysicalPopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/BiophysicalPopulationLoader.h
@@ -32,7 +32,7 @@ public:
     BiophysicalPopulationLoader();
 
     std::vector<MorphologyInstance::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.cpp
@@ -27,7 +27,7 @@
 namespace sonataloader
 {
 std::vector<MorphologyInstance::Ptr> CommonNodeLoader::loadNodes(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &networkData,
     const SonataNodePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection,
     const std::vector<std::string> &morphologyNames,
@@ -58,8 +58,9 @@ std::vector<MorphologyInstance::Ptr> CommonNodeLoader::loadNodes(
         radOverride,
         geometryMode == "smooth" && (loadAxon || loadDend));
 
-    const auto morphPath =
-        SonataConfig::resolveMorphologyPath(networkData.config.getNodePopulationProperties(lc.node_population));
+    const auto &config = networkData.circuitConfig();
+    const auto &populationName = lc.node_population;
+    const auto morphPath = SonataConfig::resolveMorphologyPath(config.getNodePopulationProperties(populationName));
 
     const auto loadFn = [&](const std::string &name, const std::vector<size_t> &indices)
     {

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/CommonNodeLoader.h
@@ -50,7 +50,7 @@ public:
      * @return a vector of morphology instances holding the geometries
      */
     std::vector<MorphologyInstance::Ptr> loadNodes(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection,
         const std::vector<std::string> &morphologyNames,

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/PointNeuronPopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/PointNeuronPopulationLoader.cpp
@@ -29,16 +29,23 @@ PointNeuronPopulationLoader::PointNeuronPopulationLoader()
 }
 
 std::vector<MorphologyInstance::Ptr> PointNeuronPopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &networkData,
     const SonataNodePopulationParameters &lc,
     const bbp::sonata::Selection &nodeSelection) const
 {
-    const auto population = networkData.config.getNodePopulation(lc.node_population);
+    const auto &populationName = lc.node_population;
+    const auto &config = networkData.circuitConfig();
+    const auto population = config.getNodePopulation(populationName);
+
     const auto nodesSize = nodeSelection.flatSize();
+
     const auto positions = SonataCells::getPositions(population, nodeSelection);
-    const auto radMult = lc.neuron_morphology_parameters.radius_multiplier;
-    const auto radOverride = lc.neuron_morphology_parameters.radius_override;
+
+    const auto &neuronParameters = lc.neuron_morphology_parameters;
+    const auto radMult = neuronParameters.radius_multiplier;
+    const auto radOverride = neuronParameters.radius_override;
     const float radius = radOverride > 0.f ? radOverride : (radMult > 0.f ? radMult : 1.f);
+
     std::vector<MorphologyInstance::Ptr> result(nodesSize);
 
     auto sharedData = std::make_shared<SampleSharedData>();

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/PointNeuronPopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/PointNeuronPopulationLoader.h
@@ -32,7 +32,7 @@ public:
     PointNeuronPopulationLoader();
 
     std::vector<MorphologyInstance::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/VasculaturePopulationLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/VasculaturePopulationLoader.cpp
@@ -29,19 +29,22 @@ VasculaturePopulationLoader::VasculaturePopulationLoader()
 }
 
 std::vector<MorphologyInstance::Ptr> VasculaturePopulationLoader::load(
-    const SonataConfig::Data &networkData,
+    const SonataNetworkConfig &networkData,
     const SonataNodePopulationParameters &lc,
     const bbp::sonata::Selection &selection) const
 {
-    const auto population = networkData.config.getNodePopulation(lc.node_population);
+    const auto &populationName = lc.node_population;
+    const auto &config = networkData.circuitConfig();
+    const auto population = config.getNodePopulation(populationName);
 
     const auto startPoints = SonataVasculature::getSegmentStartPoints(population, selection);
     const auto endPoints = SonataVasculature::getSegmentEndPoints(population, selection);
     const auto sectionTypes = SonataVasculature::getSegmentSectionTypes(population, selection);
 
     std::vector<float> startRadii, endRadii;
-    const auto radOverride = lc.vasculature_geometry_parameters.radius_override;
-    const auto radMultiplier = lc.vasculature_geometry_parameters.radius_multiplier;
+    const auto &vasculatureParameters = lc.vasculature_geometry_parameters;
+    const auto radOverride = vasculatureParameters.radius_override;
+    const auto radMultiplier = vasculatureParameters.radius_multiplier;
     if (radOverride > 0.f)
     {
         startRadii.resize(startPoints.size(), radOverride);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/VasculaturePopulationLoader.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/populations/nodes/VasculaturePopulationLoader.h
@@ -32,7 +32,7 @@ public:
     VasculaturePopulationLoader();
 
     std::vector<MorphologyInstance::Ptr> load(
-        const SonataConfig::Data &networkData,
+        const SonataNetworkConfig &networkData,
         const SonataNodePopulationParameters &loadSettings,
         const bbp::sonata::Selection &nodeSelection) const final;
 };

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/PopulationReportManager.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/PopulationReportManager.h
@@ -22,6 +22,7 @@
 
 #include <plugin/io/SonataLoaderParameters.h>
 #include <plugin/io/morphology/MorphologyInstance.h>
+#include <plugin/io/sonataloader/data/SonataConfig.h>
 #include <plugin/io/sonataloader/reports/EdgeReportLoader.h>
 #include <plugin/io/sonataloader/reports/NodeReportLoader.h>
 #include <plugin/io/synapse/SynapseGroup.h>
@@ -37,6 +38,7 @@ public:
      * the node population
      */
     static void loadNodeMapping(
+        const SonataNetworkConfig &network,
         const SonataNodePopulationParameters &input,
         const bbp::sonata::Selection &selection,
         std::vector<MorphologyInstance::Ptr> &nodes);
@@ -47,6 +49,7 @@ public:
      * the edge population
      */
     static void loadEdgeMapping(
+        const SonataNetworkConfig &network,
         const SonataEdgePopulationParameters &input,
         const bbp::sonata::Selection &selection,
         std::vector<SynapseGroup::Ptr> &edges);
@@ -57,6 +60,7 @@ public:
      * coloring and handles any special case (such as vasculature radii reports)
      */
     static void addNodeReportHandler(
+        const SonataNetworkConfig &network,
         const SonataNodePopulationParameters &input,
         const bbp::sonata::Selection &selection,
         brayns::ModelDescriptorPtr &model);
@@ -66,6 +70,7 @@ public:
      * it instantiates the appropriate simulation handler and enabled simulation
      */
     static void addEdgeReportHandler(
+        const SonataNetworkConfig &network,
         const SonataEdgePopulationParameters &input,
         const bbp::sonata::Selection &selection,
         brayns::ModelDescriptorPtr &model);

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataReportHandler.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataReportHandler.cpp
@@ -61,7 +61,13 @@ std::vector<float> SonataReportHandler::getFrameDataImpl(const uint32_t frame)
     _ready = false;
     const auto realFrame = frame > _nbFrames ? _nbFrames : frame;
     const auto timestamp = frameIndexToTimestamp(realFrame, _dt);
-    const auto data = _reportPopulation.get(_selection, timestamp).data;
+    const auto data = _reportPopulation
+                          .get(
+                              nonstd::optional<bbp::sonata::Selection>(_selection),
+                              nonstd::optional<double>(timestamp),
+                              nonstd::nullopt,
+                              nonstd::nullopt)
+                          .data;
     _ready = true;
 
     return data;

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataReportHandler.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataReportHandler.h
@@ -20,6 +20,10 @@
 
 #include <brayns/common/simulation/AbstractSimulationHandler.h>
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataSpikeHandler.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataSpikeHandler.cpp
@@ -89,7 +89,10 @@ std::vector<float> SonataSpikeHandler::getFrameDataImpl(const uint32_t frame)
 
     const auto trStart = std::max(timestamp - SPIKE_TRANSITION_TIME_SECONDS, 0.0);
     const auto trEnd = std::min(timestamp + SPIKE_TRANSITION_TIME_SECONDS, _endTime);
-    const auto readSpikes = _spikePopulation.get(_selection, trStart, trEnd);
+    const auto readSpikes = _spikePopulation.get(
+        nonstd::optional<bbp::sonata::Selection>(_selection),
+        nonstd::optional<double>(trStart),
+        nonstd::optional<double>(trEnd));
     for (const auto &spike : readSpikes)
     {
         const auto index = _gidsToIndex[spike.first];

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataSpikeHandler.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/SonataSpikeHandler.h
@@ -20,6 +20,10 @@
 
 #include <brayns/common/simulation/AbstractSimulationHandler.h>
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 #include <unordered_map>

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/VasculatureRadiiHandler.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/VasculatureRadiiHandler.cpp
@@ -63,7 +63,13 @@ std::vector<float> VasculatureRadiiHandler::getFrameDataImpl(const uint32_t fram
     _ready = false;
     const auto realFrame = frame > _nbFrames ? _nbFrames : frame;
     const auto timestamp = frameIndexToTimestamp(realFrame, _dt);
-    _radii = _reportPopulation.get(_selection, timestamp).data;
+    _radii = _reportPopulation
+                 .get(
+                     nonstd::optional<bbp::sonata::Selection>(_selection),
+                     nonstd::optional<double>(timestamp),
+                     nonstd::nullopt,
+                     nonstd::nullopt)
+                 .data;
     _ready = true;
 
     return {};

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/VasculatureRadiiHandler.h
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/handlers/VasculatureRadiiHandler.h
@@ -20,6 +20,10 @@
 
 #include <brayns/common/simulation/AbstractSimulationHandler.h>
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/loaders/EdgeCompartmentLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/loaders/EdgeCompartmentLoader.cpp
@@ -20,6 +20,10 @@
 
 #include <plugin/io/sonataloader/data/SonataSimulationMapping.h>
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 namespace sonataloader

--- a/plugins/CircuitExplorer/plugin/io/sonataloader/reports/loaders/NodeSpikeLoader.cpp
+++ b/plugins/CircuitExplorer/plugin/io/sonataloader/reports/loaders/NodeSpikeLoader.cpp
@@ -18,6 +18,10 @@
 
 #include "NodeSpikeLoader.h"
 
+// libsonata uses nonstd::optional which, if available, becomes std::optional
+// however, libsonata is compiled enforcing c++14, so their type is always nonstd::optional
+// then, symbol lookup errors happen
+#define optional_CONFIG_SELECT_OPTIONAL optional_OPTIONAL_NONSTD
 #include <bbp/sonata/report_reader.h>
 
 namespace sonataloader

--- a/plugins/deps/CMakeLists.txt
+++ b/plugins/deps/CMakeLists.txt
@@ -17,7 +17,7 @@ if(BRAYNS_CIRCUITEXPLORER_ENABLED AND NOT sonata_FOUND AND NOT TARGET sonata::so
         FetchContent_Declare(
             libsonata
             GIT_REPOSITORY https://github.com/BlueBrain/libsonata.git
-            GIT_TAG        v0.1.9
+            GIT_TAG        v0.1.11
             GIT_SHALLOW OFF # Required for its own CMakeLists.txt not to fail
             GIT_SUBMODULES_RECURSE ON
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libsonata
@@ -40,7 +40,7 @@ if(BRAYNS_CIRCUITEXPLORER_ENABLED AND NOT MorphIO_FOUND AND NOT TARGET MorphIO::
         FetchContent_Declare(
             MorphIO
             GIT_REPOSITORY https://github.com/BlueBrain/MorphIO.git
-            GIT_TAG        v3.3.2
+            GIT_TAG        v3.3.3
             GIT_SHALLOW ON
             GIT_SUBMODULES_RECURSE ON
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MorphIO
@@ -81,7 +81,7 @@ if(BRAYNS_CIRCUITEXPLORER_ENABLED AND NOT MVDTool_FOUND AND NOT TARGET MVDTool)
         FetchContent_Declare(
             MVDTool
             GIT_REPOSITORY https://github.com/BlueBrain/MVDTool.git
-            GIT_TAG        v2.4.2
+            GIT_TAG        v2.4.4
             GIT_SHALLOW ON
             #GIT_SUBMODULES # Empty string from 3.16 onwards will not clone submodules
             GIT_SUBMODULES_RECURSE OFF
@@ -109,7 +109,7 @@ if((BRAYNS_CIRCUITEXPLORER_ENABLED OR BRAYNS_CIRCUITINFO_ENABLED OR BRAYNS_DTI_E
         FetchContent_Declare(
             Brion
             GIT_REPOSITORY https://github.com/BlueBrain/Brion.git
-            GIT_TAG        3.3.7
+            GIT_TAG        3.3.8
             GIT_SHALLOW ON
             GIT_SUBMODULES_RECURSE OFF
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Brion


### PR DESCRIPTION
- Fixes std::optional vs nonstd::optional symbol missmatch caused by libsonata compiled on c++14 and brayns on c++17
- Adds support for simulation config
- Fixed SONATA loader parameter enforcement
- Updates CircuitExplorer dependencies to latest release