### PR TITLE
BRAYNS 438: Add new morphology geometry

### DIFF
--- a/brayns/engine/camera/Camera.cpp
+++ b/brayns/engine/camera/Camera.cpp
@@ -35,22 +35,6 @@ struct CameraParameters
 
 namespace brayns
 {
-Camera::Camera(Camera &&other) noexcept
-{
-    *this = other;
-}
-
-Camera &Camera::operator=(Camera &&other) noexcept
-{
-    _projectionName = std::move(other._projectionName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    _view = other._view;
-    _aspectRatio = other._aspectRatio;
-    _flag = std::move(other._flag);
-    return *this;
-}
-
 Camera::Camera(const Camera &other)
 {
     *this = other;

--- a/brayns/engine/camera/Camera.cpp
+++ b/brayns/engine/camera/Camera.cpp
@@ -35,6 +35,22 @@ struct CameraParameters
 
 namespace brayns
 {
+Camera::Camera(Camera &&other) noexcept
+{
+    *this = other;
+}
+
+Camera &Camera::operator=(Camera &&other) noexcept
+{
+    _projectionName = std::move(other._projectionName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _view = other._view;
+    _aspectRatio = other._aspectRatio;
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Camera::Camera(const Camera &other)
 {
     *this = other;
@@ -48,6 +64,7 @@ Camera &Camera::operator=(const Camera &other)
     _data->pushTo(_handle);
     setView(other._view);
     setAspectRatio(other._aspectRatio);
+    _flag = true;
     return *this;
 }
 

--- a/brayns/engine/camera/Camera.cpp
+++ b/brayns/engine/camera/Camera.cpp
@@ -35,6 +35,22 @@ struct CameraParameters
 
 namespace brayns
 {
+Camera::Camera(Camera &&other) noexcept
+{
+    *this = other;
+}
+
+Camera &Camera::operator=(Camera &&other) noexcept
+{
+    _projectionName = std::move(other._projectionName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _view = other._view;
+    _aspectRatio = other._aspectRatio;
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Camera::Camera(const Camera &other)
 {
     *this = other;

--- a/brayns/engine/camera/Camera.h
+++ b/brayns/engine/camera/Camera.h
@@ -48,8 +48,8 @@ public:
         set(std::move(data));
     }
 
-    Camera(Camera &&) = default;
-    Camera &operator=(Camera &&) = default;
+    Camera(Camera &&) noexcept;
+    Camera &operator=(Camera &&) noexcept;
 
     Camera(const Camera &);
     Camera &operator=(const Camera &);

--- a/brayns/engine/camera/Camera.h
+++ b/brayns/engine/camera/Camera.h
@@ -48,8 +48,8 @@ public:
         set(std::move(data));
     }
 
-    Camera(Camera &&) noexcept;
-    Camera &operator=(Camera &&) noexcept;
+    Camera(Camera &&) = default;
+    Camera &operator=(Camera &&) = default;
 
     Camera(const Camera &);
     Camera &operator=(const Camera &);

--- a/brayns/engine/camera/Camera.h
+++ b/brayns/engine/camera/Camera.h
@@ -48,8 +48,8 @@ public:
         set(std::move(data));
     }
 
-    Camera(Camera &&) noexcept = default;
-    Camera &operator=(Camera &&) noexcept = default;
+    Camera(Camera &&) noexcept;
+    Camera &operator=(Camera &&) noexcept;
 
     Camera(const Camera &);
     Camera &operator=(const Camera &);

--- a/brayns/engine/geometry/Geometry.cpp
+++ b/brayns/engine/geometry/Geometry.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Geometry::Geometry(Geometry &&other) noexcept
+{
+    *this = other;
+}
+
+Geometry &Geometry::operator=(Geometry &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _geometryName = std::move(other._geometryName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Geometry::Geometry(const Geometry &other)
 {
     *this = other;

--- a/brayns/engine/geometry/Geometry.cpp
+++ b/brayns/engine/geometry/Geometry.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Geometry::Geometry(Geometry &&other) noexcept
+{
+    *this = other;
+}
+
+Geometry &Geometry::operator=(Geometry &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _geometryName = std::move(other._geometryName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Geometry::Geometry(const Geometry &other)
 {
     *this = other;
@@ -33,6 +48,7 @@ Geometry &Geometry::operator=(const Geometry &other)
     _geometryName = other._geometryName;
     _handle = ospray::cpp::Geometry(_handleName);
     _data = other._data->clone();
+    _flag = true;
     return *this;
 }
 

--- a/brayns/engine/geometry/Geometry.cpp
+++ b/brayns/engine/geometry/Geometry.cpp
@@ -22,21 +22,6 @@
 
 namespace brayns
 {
-Geometry::Geometry(Geometry &&other) noexcept
-{
-    *this = other;
-}
-
-Geometry &Geometry::operator=(Geometry &&other) noexcept
-{
-    _handleName = std::move(other._handleName);
-    _geometryName = std::move(other._geometryName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    _flag = std::move(other._flag);
-    return *this;
-}
-
 Geometry::Geometry(const Geometry &other)
 {
     *this = other;

--- a/brayns/engine/geometry/Geometry.h
+++ b/brayns/engine/geometry/Geometry.h
@@ -55,8 +55,8 @@ public:
     {
     }
 
-    Geometry(Geometry &&) noexcept = default;
-    Geometry &operator=(Geometry &&) noexcept = default;
+    Geometry(Geometry &&) noexcept;
+    Geometry &operator=(Geometry &&) noexcept;
 
     Geometry(const Geometry &other);
     Geometry &operator=(const Geometry &other);

--- a/brayns/engine/geometry/Geometry.h
+++ b/brayns/engine/geometry/Geometry.h
@@ -55,8 +55,8 @@ public:
     {
     }
 
-    Geometry(Geometry &&) noexcept;
-    Geometry &operator=(Geometry &&) noexcept;
+    Geometry(Geometry &&) = default;
+    Geometry &operator=(Geometry &&) = default;
 
     Geometry(const Geometry &other);
     Geometry &operator=(const Geometry &other);

--- a/brayns/engine/geometry/Geometry.h
+++ b/brayns/engine/geometry/Geometry.h
@@ -55,8 +55,8 @@ public:
     {
     }
 
-    Geometry(Geometry &&) = default;
-    Geometry &operator=(Geometry &&) = default;
+    Geometry(Geometry &&) noexcept;
+    Geometry &operator=(Geometry &&) noexcept;
 
     Geometry(const Geometry &other);
     Geometry &operator=(const Geometry &other);

--- a/brayns/engine/light/Light.cpp
+++ b/brayns/engine/light/Light.cpp
@@ -22,6 +22,20 @@
 
 namespace brayns
 {
+Light::Light(Light &&other) noexcept
+{
+    *this = other;
+}
+
+Light &Light::operator=(Light &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _lightName = std::move(other._lightName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    return *this;
+}
+
 Light::Light(const Light &other)
 {
     *this = other;

--- a/brayns/engine/light/Light.cpp
+++ b/brayns/engine/light/Light.cpp
@@ -22,20 +22,6 @@
 
 namespace brayns
 {
-Light::Light(Light &&other) noexcept
-{
-    *this = other;
-}
-
-Light &Light::operator=(Light &&other) noexcept
-{
-    _handleName = std::move(other._handleName);
-    _lightName = std::move(other._lightName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    return *this;
-}
-
 Light::Light(const Light &other)
 {
     *this = other;

--- a/brayns/engine/light/Light.h
+++ b/brayns/engine/light/Light.h
@@ -52,8 +52,8 @@ public:
         _handle.commit();
     }
 
-    Light(Light &&) = default;
-    Light &operator=(Light &&) = default;
+    Light(Light &&) noexcept;
+    Light &operator=(Light &&) noexcept;
 
     Light(const Light &other);
     Light &operator=(const Light &other);

--- a/brayns/engine/light/Light.h
+++ b/brayns/engine/light/Light.h
@@ -52,8 +52,8 @@ public:
         _handle.commit();
     }
 
-    Light(Light &&) noexcept;
-    Light &operator=(Light &&) noexcept;
+    Light(Light &&) = default;
+    Light &operator=(Light &&) = default;
 
     Light(const Light &other);
     Light &operator=(const Light &other);

--- a/brayns/engine/light/Light.h
+++ b/brayns/engine/light/Light.h
@@ -52,8 +52,8 @@ public:
         _handle.commit();
     }
 
-    Light(Light &&) noexcept = default;
-    Light &operator=(Light &&) noexcept = default;
+    Light(Light &&) noexcept;
+    Light &operator=(Light &&) noexcept;
 
     Light(const Light &other);
     Light &operator=(const Light &other);

--- a/brayns/engine/material/Material.cpp
+++ b/brayns/engine/material/Material.cpp
@@ -23,21 +23,6 @@
 
 namespace brayns
 {
-Material::Material(Material &&other) noexcept
-{
-    *this = other;
-}
-
-Material &Material::operator=(Material &&other) noexcept
-{
-    _handleName = std::move(other._handleName);
-    _materialName = std::move(other._materialName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    _flag = std::move(other._flag);
-    return *this;
-}
-
 Material::Material(const Material &other)
 {
     *this = other;

--- a/brayns/engine/material/Material.cpp
+++ b/brayns/engine/material/Material.cpp
@@ -23,6 +23,21 @@
 
 namespace brayns
 {
+Material::Material(Material &&other) noexcept
+{
+    *this = other;
+}
+
+Material &Material::operator=(Material &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _materialName = std::move(other._materialName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Material::Material(const Material &other)
 {
     *this = other;

--- a/brayns/engine/material/Material.cpp
+++ b/brayns/engine/material/Material.cpp
@@ -23,6 +23,21 @@
 
 namespace brayns
 {
+Material::Material(Material &&other) noexcept
+{
+    *this = other;
+}
+
+Material &Material::operator=(Material &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _materialName = std::move(other._materialName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Material::Material(const Material &other)
 {
     *this = other;
@@ -35,6 +50,7 @@ Material &Material::operator=(const Material &other)
     _handle = ospray::cpp::Material("", _handleName);
     _data = other._data->clone();
     _data->pushTo(_handle);
+    _flag = true;
     return *this;
 }
 

--- a/brayns/engine/material/Material.h
+++ b/brayns/engine/material/Material.h
@@ -52,8 +52,8 @@ public:
         _data->pushTo(_handle);
     }
 
-    Material(Material &&) noexcept;
-    Material &operator=(Material &&) noexcept;
+    Material(Material &&) = default;
+    Material &operator=(Material &&) = default;
 
     Material(const Material &other);
     Material &operator=(const Material &other);

--- a/brayns/engine/material/Material.h
+++ b/brayns/engine/material/Material.h
@@ -52,8 +52,8 @@ public:
         _data->pushTo(_handle);
     }
 
-    Material(Material &&) noexcept = default;
-    Material &operator=(Material &&) noexcept = default;
+    Material(Material &&) noexcept;
+    Material &operator=(Material &&) noexcept;
 
     Material(const Material &other);
     Material &operator=(const Material &other);

--- a/brayns/engine/material/Material.h
+++ b/brayns/engine/material/Material.h
@@ -52,8 +52,8 @@ public:
         _data->pushTo(_handle);
     }
 
-    Material(Material &&) = default;
-    Material &operator=(Material &&) = default;
+    Material(Material &&) noexcept;
+    Material &operator=(Material &&) noexcept;
 
     Material(const Material &other);
     Material &operator=(const Material &other);

--- a/brayns/engine/renderer/Renderer.cpp
+++ b/brayns/engine/renderer/Renderer.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Renderer::Renderer(Renderer &&other) noexcept
+{
+    *this = other;
+}
+
+Renderer &Renderer::operator=(Renderer &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _rendererName = std::move(other._rendererName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Renderer::Renderer(const Renderer &other)
 {
     *this = other;

--- a/brayns/engine/renderer/Renderer.cpp
+++ b/brayns/engine/renderer/Renderer.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Renderer::Renderer(Renderer &&other) noexcept
+{
+    *this = other;
+}
+
+Renderer &Renderer::operator=(Renderer &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _rendererName = std::move(other._rendererName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Renderer::Renderer(const Renderer &other)
 {
     *this = other;
@@ -34,6 +49,7 @@ Renderer &Renderer::operator=(const Renderer &other)
     _handle = ospray::cpp::Renderer(_handleName);
     _data = other._data->clone();
     _data->pushTo(_handle);
+    _flag = true;
     return *this;
 }
 

--- a/brayns/engine/renderer/Renderer.cpp
+++ b/brayns/engine/renderer/Renderer.cpp
@@ -22,21 +22,6 @@
 
 namespace brayns
 {
-Renderer::Renderer(Renderer &&other) noexcept
-{
-    *this = other;
-}
-
-Renderer &Renderer::operator=(Renderer &&other) noexcept
-{
-    _handleName = std::move(other._handleName);
-    _rendererName = std::move(other._rendererName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    _flag = std::move(other._flag);
-    return *this;
-}
-
 Renderer::Renderer(const Renderer &other)
 {
     *this = other;

--- a/brayns/engine/renderer/Renderer.h
+++ b/brayns/engine/renderer/Renderer.h
@@ -43,8 +43,8 @@ public:
         set(std::move(data));
     }
 
-    Renderer(Renderer &&) noexcept;
-    Renderer &operator=(Renderer &&) noexcept;
+    Renderer(Renderer &&) = default;
+    Renderer &operator=(Renderer &&) = default;
 
     Renderer(const Renderer &other);
     Renderer &operator=(const Renderer &other);

--- a/brayns/engine/renderer/Renderer.h
+++ b/brayns/engine/renderer/Renderer.h
@@ -43,8 +43,8 @@ public:
         set(std::move(data));
     }
 
-    Renderer(Renderer &&) = default;
-    Renderer &operator=(Renderer &&) = default;
+    Renderer(Renderer &&) noexcept;
+    Renderer &operator=(Renderer &&) noexcept;
 
     Renderer(const Renderer &other);
     Renderer &operator=(const Renderer &other);

--- a/brayns/engine/renderer/Renderer.h
+++ b/brayns/engine/renderer/Renderer.h
@@ -43,8 +43,8 @@ public:
         set(std::move(data));
     }
 
-    Renderer(Renderer &&) noexcept = default;
-    Renderer &operator=(Renderer &&) noexcept = default;
+    Renderer(Renderer &&) noexcept;
+    Renderer &operator=(Renderer &&) noexcept;
 
     Renderer(const Renderer &other);
     Renderer &operator=(const Renderer &other);

--- a/brayns/engine/volume/Volume.cpp
+++ b/brayns/engine/volume/Volume.cpp
@@ -22,21 +22,6 @@
 
 namespace brayns
 {
-Volume::Volume(Volume &&other) noexcept
-{
-    *this = other;
-}
-
-Volume &Volume::operator=(Volume &&other) noexcept
-{
-    _handleName = std::move(other._handleName);
-    _volumeName = std::move(other._volumeName);
-    _handle = std::move(other._handle);
-    _data = std::move(other._data);
-    _flag = std::move(other._flag);
-    return *this;
-}
-
 Volume::Volume(const Volume &other)
 {
     *this = other;

--- a/brayns/engine/volume/Volume.cpp
+++ b/brayns/engine/volume/Volume.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Volume::Volume(Volume &&other) noexcept
+{
+    *this = other;
+}
+
+Volume &Volume::operator=(Volume &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _volumeName = std::move(other._volumeName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Volume::Volume(const Volume &other)
 {
     *this = other;

--- a/brayns/engine/volume/Volume.cpp
+++ b/brayns/engine/volume/Volume.cpp
@@ -22,6 +22,21 @@
 
 namespace brayns
 {
+Volume::Volume(Volume &&other) noexcept
+{
+    *this = other;
+}
+
+Volume &Volume::operator=(Volume &&other) noexcept
+{
+    _handleName = std::move(other._handleName);
+    _volumeName = std::move(other._volumeName);
+    _handle = std::move(other._handle);
+    _data = std::move(other._data);
+    _flag = std::move(other._flag);
+    return *this;
+}
+
 Volume::Volume(const Volume &other)
 {
     *this = other;
@@ -33,6 +48,7 @@ Volume &Volume::operator=(const Volume &other)
     _volumeName = other._volumeName;
     _handle = ospray::cpp::Volume(_handleName);
     _data = other._data->clone();
+    _flag = true;
     return *this;
 }
 

--- a/brayns/engine/volume/Volume.h
+++ b/brayns/engine/volume/Volume.h
@@ -54,8 +54,8 @@ public:
     {
     }
 
-    Volume(Volume &&) noexcept = default;
-    Volume &operator=(Volume &&) noexcept = default;
+    Volume(Volume &&) noexcept;
+    Volume &operator=(Volume &&) noexcept;
 
     Volume(const Volume &other);
     Volume &operator=(const Volume &other);

--- a/brayns/engine/volume/Volume.h
+++ b/brayns/engine/volume/Volume.h
@@ -54,8 +54,8 @@ public:
     {
     }
 
-    Volume(Volume &&) = default;
-    Volume &operator=(Volume &&) = default;
+    Volume(Volume &&) noexcept;
+    Volume &operator=(Volume &&) noexcept;
 
     Volume(const Volume &other);
     Volume &operator=(const Volume &other);

--- a/brayns/engine/volume/Volume.h
+++ b/brayns/engine/volume/Volume.h
@@ -54,8 +54,8 @@ public:
     {
     }
 
-    Volume(Volume &&) noexcept;
-    Volume &operator=(Volume &&) noexcept;
+    Volume(Volume &&) = default;
+    Volume &operator=(Volume &&) = default;
 
     Volume(const Volume &other);
     Volume &operator=(const Volume &other);

--- a/brayns/network/entrypoints/ModelMaterialEntrypoint.h
+++ b/brayns/network/entrypoints/ModelMaterialEntrypoint.h
@@ -64,7 +64,7 @@ public:
         auto &component = model.getComponent<MaterialComponent>();
         MaterialType materialData;
         buffer.extract(materialData);
-        component.setMaterial(Material(materialData));
+        component.setMaterial(Material(std::move(materialData)));
         request.reply(EmptyMessage());
     }
 

--- a/plugins/CircuitExplorer/api/neuron/NeuronMorphologyPipeline.cpp
+++ b/plugins/CircuitExplorer/api/neuron/NeuronMorphologyPipeline.cpp
@@ -20,6 +20,7 @@
 
 #include "processors/ConstantRadius.h"
 #include "processors/RadiusMultiplier.h"
+#include "processors/SectionSmoother.h"
 #include "processors/Smoother.h"
 
 namespace
@@ -35,6 +36,9 @@ public:
         {
         case NeuronGeometryType::ConstantRadii:
             stages.push_back(std::make_unique<ConstantRadius>());
+            break;
+        case NeuronGeometryType::SectionSmooth:
+            stages.push_back(std::make_unique<SectionSmoother>());
             break;
         case NeuronGeometryType::Smooth:
             stages.push_back(std::make_unique<Smoother>());

--- a/plugins/CircuitExplorer/api/neuron/processors/SectionSmoother.cpp
+++ b/plugins/CircuitExplorer/api/neuron/processors/SectionSmoother.cpp
@@ -1,0 +1,133 @@
+/* Copyright (c) 2015-2022, EPFL/Blue Brain Project
+ * All rights reserved. Do not distribute without permission.
+ * Responsible Author: Nadir Roman <nadir.romanguerrero@epfl.ch>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "SectionSmoother.h"
+
+#include <deque>
+
+namespace
+{
+class SmoothQueue
+{
+public:
+    void append(const std::vector<size_t> &indices)
+    {
+        _smoothQueue.insert(_smoothQueue.end(), indices.begin(), indices.end());
+    }
+
+    size_t next() noexcept
+    {
+        auto next = _smoothQueue.front();
+        _smoothQueue.pop_front();
+        return next;
+    }
+
+    bool empty() const noexcept
+    {
+        return _smoothQueue.empty();
+    }
+
+private:
+    std::deque<size_t> _smoothQueue;
+};
+
+class ParentChildrenSmoother
+{
+public:
+    ParentChildrenSmoother(float somaRadiusMultiplier, float sectionRadiusChange)
+        : _somaRadiusMultiplier(somaRadiusMultiplier)
+        , _sectionRadiusChange(sectionRadiusChange)
+    {
+        assert(somaRadiusMultiplier > 0.f);
+        assert(_sectionRadiusChange >= 0.f && _sectionRadiusChange <= 1.f);
+    }
+
+    void apply(NeuronMorphology &morphology)
+    {
+        SmoothQueue queue;
+        _initializeRootSections(morphology, queue);
+
+        while (!queue.empty())
+        {
+            auto parentIndex = queue.next();
+            auto parentSection = _getSection(morphology, parentIndex);
+            auto parentRadius = parentSection.samples.front().radius;
+
+            auto childSections = morphology.sectionChildrenIndices(parentSection.id);
+            auto childrenRadius = parentRadius * (1.f - _sectionRadiusChange);
+            _setSectionRadius(morphology, childSections, childrenRadius);
+
+            queue.append(childSections);
+        }
+    }
+
+private:
+    void _initializeRootSections(NeuronMorphology &morphology, SmoothQueue &queue)
+    {
+        auto somaChildren = morphology.sectionChildrenIndices(-1);
+        queue.append(somaChildren);
+        if (!morphology.hasSoma())
+        {
+            return;
+        }
+
+        auto startingRadius = morphology.soma().radius * _somaRadiusMultiplier;
+        _setSectionRadius(morphology, somaChildren, startingRadius);
+    }
+
+    void _setSectionRadius(NeuronMorphology &morphology, const std::vector<size_t> &sectionIndices, float radius)
+    {
+        auto &sections = morphology.sections();
+        for (auto sectionIndex : sectionIndices)
+        {
+            auto &section = sections[sectionIndex];
+            for (auto &sample : section.samples)
+            {
+                sample.radius = radius;
+            }
+        }
+    }
+
+    const NeuronMorphology::Section &_getSection(const NeuronMorphology &morphology, size_t sectionIndex)
+    {
+        auto &sections = morphology.sections();
+        auto &section = sections[sectionIndex];
+        return section;
+    }
+
+    float _getSectionRadius(const NeuronMorphology &morphology, size_t sectionIndex)
+    {
+        auto &sections = morphology.sections();
+        auto &section = sections[sectionIndex];
+        auto &samples = section.samples;
+        return samples.front().radius;
+    }
+
+private:
+    float _somaRadiusMultiplier;
+    float _sectionRadiusChange;
+};
+} // namespace
+
+void SectionSmoother::process(NeuronMorphology &morphology) const
+{
+    constexpr float somaRadiusMultiplier = 0.25f;
+    constexpr float sectionRadiusChange = 0.11f;
+    ParentChildrenSmoother smoother(somaRadiusMultiplier, sectionRadiusChange);
+    smoother.apply(morphology);
+}

--- a/plugins/CircuitExplorer/api/neuron/processors/SectionSmoother.h
+++ b/plugins/CircuitExplorer/api/neuron/processors/SectionSmoother.h
@@ -1,8 +1,6 @@
 /* Copyright (c) 2015-2022, EPFL/Blue Brain Project
  * All rights reserved. Do not distribute without permission.
- * Responsible Author: Nadir Roman Guerrero <nadir.romanguerrero@epfl.ch>
- *
- * This file is part of Brayns <https://github.com/BlueBrain/Brayns>
+ * Responsible Author: Nadir Roman <nadir.romanguerrero@epfl.ch>
  *
  * This library is free software; you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License version 3.0 as published
@@ -20,10 +18,14 @@
 
 #pragma once
 
-enum class NeuronGeometryType
+#include <api/neuron/INeuronMorphologyProcessor.h>
+
+/**
+ * @brief Applies a smoothing kernel that softens the radius changes from section to section,
+ * whilst section radii are constant
+ */
+class SectionSmoother final : public INeuronMorphologyProcessor
 {
-    Original,
-    Smooth,
-    SectionSmooth,
-    ConstantRadii
+public:
+    void process(NeuronMorphology &morphology) const override;
 };

--- a/plugins/CircuitExplorer/io/NeuronMorphologyLoaderParameters.h
+++ b/plugins/CircuitExplorer/io/NeuronMorphologyLoaderParameters.h
@@ -30,6 +30,7 @@ BRAYNS_JSON_ADAPTER_ENUM(
     NeuronGeometryType,
     {"original", NeuronGeometryType::Original},
     {"smooth", NeuronGeometryType::Smooth},
+    {"section_smooth", NeuronGeometryType::SectionSmooth},
     {"constant_radii", NeuronGeometryType::ConstantRadii})
 }
 

--- a/python/brayns/plugins/morphology/geometry_type.py
+++ b/python/brayns/plugins/morphology/geometry_type.py
@@ -25,9 +25,11 @@ class GeometryType(Enum):
 
     :param ORIGINAL: Use raw geometries dimensions.
     :param SMOOTH: Smooth radius changes between geometries for better visual.
+    :param SECTION_SMOOTH: Smooth radius change between whole sections.
     :param CONSTANT_RADII: Apply the same radius to all geometries.
     """
 
     ORIGINAL = 'original'
     SMOOTH = 'smooth'
+    SECTION_SMOOTH = 'section_smooth'
     CONSTANT_RADII = 'constant_radii'


### PR DESCRIPTION
**This PR also fixes engine objects (camera/geometry/light/material/renderer/volume) move constructors and assigments:**
Because OSPRay move constructor/assigment are not declared noexcept, default noexcept move constructor/assigment on engine objects were not meeting the required constraints to be used by the standard library.
The options were to declared them without the noexcept specifier, or write them manually noexcept (It is safe since the OSPray object do not throw on move constructor/assigment).
The latter was choosen as this enables underneath stl operations that works with std::move_if_noexcept