### PR TITLE
Brayns 458 - Fix efferent synapse load

### DIFF
--- a/brayns/engine/geometry/types/BoundedPlane.cpp
+++ b/brayns/engine/geometry/types/BoundedPlane.cpp
@@ -40,7 +40,7 @@ Bounds GeometryTraits<BoundedPlane>::computeBounds(const Matrix4f &matrix, const
 
 void GeometryTraits<BoundedPlane>::updateData(ospray::cpp::Geometry &handle, std::vector<BoundedPlane> &data)
 {
-    constexpr auto stride = sizeof(float) * 10;
+    auto stride = sizeof(BoundedPlane);
 
     auto &first = data.front();
     auto size = data.size();

--- a/plugins/CircuitExplorer/io/BBPLoader.cpp
+++ b/plugins/CircuitExplorer/io/BBPLoader.cpp
@@ -60,7 +60,7 @@ struct SynapseImporter
             updater.update("Loading efferent synapses");
             modelList.push_back(std::make_unique<brayns::Model>());
             auto &model = *(modelList.back());
-            bbploader::SynapseLoader::load(context, true, model);
+            bbploader::SynapseLoader::load(context, false, model);
         }
     }
 };

--- a/python/brayns/core/geometry/bounded_plane.py
+++ b/python/brayns/core/geometry/bounded_plane.py
@@ -21,43 +21,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from multiprocessing.sharedctypes import Value
 from typing import Any
 
+from brayns.utils import Bounds
+from brayns.utils import PlaneEquation
+from brayns.utils.bounds import serialize_bounds
+
 from .geometry import Geometry
-from .box import Box
 
 
 @dataclass
 class BoundedPlane(Geometry):
     """Axis-aligned bounded plane.
 
-    Described by the equation ``ax + by + cz + d = 0``.
-
-    Where [a, b, c] is the normal of the plane and d the orthogonal distance
-    from the origin.
-
-    :param a: X term of the plane equation.
-    :type a: float
-    :param b: Y term of the plane equation.
-    :type b: float
-    :param c: Y term of the plane equation.
-    :type c: float
-    :param d: Scalar term of the plane equation.
-    :type d: float
+    :param equation: Plane equation coefficients.
+    :type equation: PlaneEquation
     :param bounds: Axis aligned bounds to limit the plane.
-    :type bounds: Box
+    :type bounds: Bounds
     """
 
-    a: float
-    b: float
-    c: float
-    d: float
-    bounds: Box
+    equation: PlaneEquation
+    bounds: Bounds
 
-    def __new__(cls, a: float, b: float, c: float, d: float, bounds: Box) -> BoundedPlane:
-        diff = bounds.max - bounds.min
-        if diff.x <= 0 or diff.y <= 0 or diff.z <= 0:
+    def __new__(cls, equation: PlaneEquation, bounds: Bounds) -> BoundedPlane:
+        if min(bounds.size) <= 0:
             raise ValueError("All bound dimensions must be greater than 0")
         return object.__new__(cls)
 
@@ -74,6 +61,6 @@ class BoundedPlane(Geometry):
     def get_additional_properties(self) -> dict[str, Any]:
         """Low level API to serialize to JSON."""
         return {
-            'coefficients': [self.a, self.b, self.c, self.d],
-            'bounds': self.bounds.get_additional_properties(),
+            'coefficients': list(self.equation),
+            'bounds': serialize_bounds(self.bounds),
         }

--- a/python/testapi/core/geometry/test_add_bounded_planes.py
+++ b/python/testapi/core/geometry/test_add_bounded_planes.py
@@ -22,7 +22,7 @@ import brayns
 from testapi.simple_test_case import SimpleTestCase
 
 
-class TestAddBoxes(SimpleTestCase):
+class TestAddBoundedPlanes(SimpleTestCase):
 
     def test_add_bounded_planes(self) -> None:
         test = brayns.add_geometries(self.instance, [

--- a/python/testapi/core/geometry/test_add_bounded_planes.py
+++ b/python/testapi/core/geometry/test_add_bounded_planes.py
@@ -27,21 +27,15 @@ class TestAddBoundedPlanes(SimpleTestCase):
     def test_add_bounded_planes(self) -> None:
         test = brayns.add_geometries(self.instance, [
             brayns.BoundedPlane(
-                a=0,
-                b=0,
-                c=1,
-                d=0,
-                bounds=brayns.Box(
+                brayns.PlaneEquation(0, 0, 1, 0),
+                bounds=brayns.Bounds(
                     min=-brayns.Vector3.one,
                     max=brayns.Vector3.one
                 )
             ).with_color(brayns.Color4.red),
             brayns.BoundedPlane(
-                a=0,
-                b=0,
-                c=1,
-                d=0.5,
-                bounds=brayns.Box(
+                brayns.PlaneEquation(0, 0, 1, 0.5),
+                bounds=brayns.Bounds(
                     min=-2 * brayns.Vector3.one,
                     max=brayns.Vector3.one
                 )

--- a/python/tests/core/geometry/test_bounded_plane.py
+++ b/python/tests/core/geometry/test_bounded_plane.py
@@ -30,11 +30,8 @@ class TestBoundedPlane(unittest.TestCase):
 
     def test_get_properties(self) -> None:
         bounded_plane = brayns.BoundedPlane(
-            a=0,
-            b=0,
-            c=1,
-            d=0,
-            bounds=brayns.Box(
+            brayns.PlaneEquation(0, 0, 1, 0),
+            bounds=brayns.Bounds(
                 min=brayns.Vector3.zero,
                 max=brayns.Vector3.one,
             )


### PR DESCRIPTION
Also:
* Fixes bounded plane test names.
* Use bounds and plane equation on the bounded plane object.