### PR TITLE
BRAYNS 477 - Compartment loading optimization

### DIFF
--- a/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
+++ b/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
@@ -107,18 +107,20 @@ std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Co
     auto &positions = context.positions;
     auto radius = context.radius;
 
-    std::vector<CellCompartments> result(ids.size());
-    std::vector<brayns::Sphere> geometry(ids.size());
+    auto result = std::vector<CellCompartments>();
+    result.reserve(ids.size());
+    auto geometry = std::vector<brayns::Sphere>();
+    geometry.reserve(ids.size());
 
-#pragma omp parallel for
+    //#pragma omp parallel for
     for (size_t i = 0; i < ids.size(); ++i)
     {
         auto &pos = positions[i];
-        auto &somaSphere = geometry[i];
+        auto &somaSphere = geometry.emplace_back(); //[i];
         somaSphere.center = pos;
         somaSphere.radius = radius;
 
-        auto &compartment = result[i];
+        auto &compartment = result.emplace_back(); //[i];
 
         compartment.numItems = 1;
         compartment.sectionSegments = {{-1, std::vector<uint64_t>{0ul}}}; //[-1].push_back(0);

--- a/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
+++ b/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
@@ -112,18 +112,16 @@ std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Co
     auto geometry = std::vector<brayns::Sphere>();
     geometry.reserve(ids.size());
 
-    //#pragma omp parallel for
     for (size_t i = 0; i < ids.size(); ++i)
     {
         auto &pos = positions[i];
-        auto &somaSphere = geometry.emplace_back(); //[i];
+        auto &somaSphere = geometry.emplace_back();
         somaSphere.center = pos;
         somaSphere.radius = radius;
 
-        auto &compartment = result.emplace_back(); //[i];
-
+        auto &compartment = result.emplace_back();
         compartment.numItems = 1;
-        compartment.sectionSegments = {{-1, std::vector<uint64_t>{0ul}}}; //[-1].push_back(0);
+        compartment.sectionSegments = {{-1, std::vector<uint64_t>{0ul}}};
     }
 
     auto builder = ModelBuilder(model);

--- a/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
+++ b/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
@@ -103,9 +103,9 @@ private:
 
 std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Context context)
 {
-    const auto &ids = context.ids;
-    const auto &positions = context.positions;
-    const auto radius = context.radius;
+    auto &ids = context.ids;
+    auto &positions = context.positions;
+    auto radius = context.radius;
 
     std::vector<CellCompartments> result(ids.size());
     std::vector<brayns::Sphere> geometry(ids.size());
@@ -113,7 +113,7 @@ std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Co
 #pragma omp parallel for
     for (size_t i = 0; i < ids.size(); ++i)
     {
-        const auto &pos = positions[i];
+        auto &pos = positions[i];
         auto &somaSphere = geometry[i];
         somaSphere.center = pos;
         somaSphere.radius = radius;
@@ -121,7 +121,7 @@ std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Co
         auto &compartment = result[i];
 
         compartment.numItems = 1;
-        compartment.sectionSegments[-1].push_back(0);
+        compartment.sectionSegments = {{-1, std::vector<uint64_t>{0ul}}}; //[-1].push_back(0);
     }
 
     auto builder = ModelBuilder(model);

--- a/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
+++ b/plugins/CircuitExplorer/api/circuit/SomaCircuitBuilder.cpp
@@ -103,25 +103,18 @@ private:
 
 std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Context context)
 {
-    auto &ids = context.ids;
     auto &positions = context.positions;
     auto radius = context.radius;
 
-    auto result = std::vector<CellCompartments>();
-    result.reserve(ids.size());
+    auto compartments = std::vector<CellCompartments>();
+    compartments.reserve(positions.size());
     auto geometry = std::vector<brayns::Sphere>();
-    geometry.reserve(ids.size());
+    geometry.reserve(positions.size());
 
-    for (size_t i = 0; i < ids.size(); ++i)
+    for (auto &position : positions)
     {
-        auto &pos = positions[i];
-        auto &somaSphere = geometry.emplace_back();
-        somaSphere.center = pos;
-        somaSphere.radius = radius;
-
-        auto &compartment = result.emplace_back();
-        compartment.numItems = 1;
-        compartment.sectionSegments = {{-1, std::vector<uint64_t>{0ul}}};
+        geometry.push_back({position, radius});
+        compartments.push_back({1, {{-1, std::vector<uint64_t>{0ul}}}});
     }
 
     auto builder = ModelBuilder(model);
@@ -130,5 +123,5 @@ std::vector<CellCompartments> SomaCircuitBuilder::build(brayns::Model &model, Co
     builder.addColoring(std::move(context.colorData));
     builder.addDefaultColor();
 
-    return result;
+    return compartments;
 }

--- a/plugins/CircuitExplorer/api/reports/IReportData.h
+++ b/plugins/CircuitExplorer/api/reports/IReportData.h
@@ -63,5 +63,5 @@ public:
      * @param frameIndex
      * @return std::vector<float>
      */
-    virtual std::vector<float> getFrame(const uint32_t frameIndex) const = 0;
+    virtual std::vector<float> getFrame(uint32_t frameIndex) const = 0;
 };

--- a/plugins/CircuitExplorer/api/reports/IReportData.h
+++ b/plugins/CircuitExplorer/api/reports/IReportData.h
@@ -30,13 +30,6 @@ public:
     virtual ~IReportData() = default;
 
     /**
-     * @brief Returns the size, in bytes, of a single frame
-     *
-     * @return size_t
-     */
-    virtual size_t getFrameSize() const noexcept = 0;
-
-    /**
      * @brief Returns the report start time
      *
      * @return float

--- a/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.cpp
+++ b/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.cpp
@@ -20,12 +20,20 @@
 
 #include <cmath>
 
-float FrameTimeCalculator::compute(const uint32_t frame, const float start, const float end, const float dt) noexcept
+float FrameTimeCalculator::compute(uint32_t frame, float start, float end, float dt) noexcept
 {
-    const auto upRoundedDt = std::nextafter(dt, std::numeric_limits<float>::infinity());
+    auto upRoundedDt = std::nextafter(dt, std::numeric_limits<float>::infinity());
     auto timeStamp = start + frame * upRoundedDt;
 
-    timeStamp = timeStamp < start ? start : (timeStamp > end ? end : timeStamp);
+    if (timeStamp < start)
+    {
+        return start;
+    }
+
+    if (timeStamp >= end)
+    {
+        return end - upRoundedDt;
+    }
 
     return timeStamp;
 }

--- a/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.cpp
+++ b/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.cpp
@@ -23,6 +23,7 @@
 float FrameTimeCalculator::compute(uint32_t frame, float start, float end, float dt) noexcept
 {
     auto upRoundedDt = std::nextafter(dt, std::numeric_limits<float>::infinity());
+
     auto timeStamp = start + frame * upRoundedDt;
 
     if (timeStamp < start)
@@ -30,9 +31,9 @@ float FrameTimeCalculator::compute(uint32_t frame, float start, float end, float
         return start;
     }
 
-    if (timeStamp >= end)
+    if (auto upperLimit = end - upRoundedDt; timeStamp >= upperLimit)
     {
-        return end - upRoundedDt;
+        return upperLimit;
     }
 
     return timeStamp;

--- a/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.h
+++ b/plugins/CircuitExplorer/api/reports/common/FrameTimeCalculator.h
@@ -23,7 +23,8 @@
 /**
  * @brief Transforms a frame integer index into its timestamp based on the report start, end and timestep values
  */
-struct FrameTimeCalculator
+class FrameTimeCalculator
 {
-    static float compute(const uint32_t frame, const float start, const float end, const float dt) noexcept;
+public:
+    static float compute(uint32_t frame, float start, float end, float dt) noexcept;
 };

--- a/plugins/CircuitExplorer/api/reports/indexers/OffsetIndexer.cpp
+++ b/plugins/CircuitExplorer/api/reports/indexers/OffsetIndexer.cpp
@@ -57,16 +57,16 @@ private:
         const CellCompartments &cellStructure,
         const CellReportMapping &cellReportMapping)
     {
-        const auto size = cellStructure.numItems;
-        const auto &compartmentMap = cellStructure.sectionSegments;
+        auto size = cellStructure.numItems;
+        auto &compartmentMap = cellStructure.sectionSegments;
 
-        const auto offset = cellReportMapping.globalOffset;
-        const auto &localOffsets = cellReportMapping.offsets;
-        const auto &compartments = cellReportMapping.compartments;
+        auto offset = cellReportMapping.globalOffset;
+        auto &localOffsets = cellReportMapping.offsets;
+        auto &compartments = cellReportMapping.compartments;
 
         std::vector<uint64_t> localResult(size, offset);
 
-        for (const auto &[sectionId, segments] : compartmentMap)
+        for (auto &[sectionId, segments] : compartmentMap)
         {
             // No section level information (soma report, spike simulation, etc.) or dealing with soma
             if (sectionId < 0 || localOffsets.empty() || static_cast<size_t>(sectionId) >= localOffsets.size())
@@ -74,15 +74,16 @@ private:
                 continue;
             }
 
-            const auto numSegments = segments.size();
-            const auto numCompartments = compartments[sectionId];
-            const auto step = float(numCompartments) / float(numSegments);
-            const size_t sectionOffset = localOffsets[sectionId];
+            auto numSegments = segments.size();
+            auto numCompartments = compartments[sectionId];
+            auto step = static_cast<float>(numCompartments) / static_cast<float>(numSegments);
+            auto sectionOffset = localOffsets[sectionId];
+
             for (size_t i = 0; i < segments.size(); ++i)
             {
-                const auto compartment = static_cast<size_t>(step * i);
-                const auto finalOffset = offset + sectionOffset + compartment;
-                const auto segmentIndex = segments[i];
+                auto compartment = static_cast<size_t>(step * i);
+                auto finalOffset = offset + sectionOffset + compartment;
+                auto segmentIndex = segments[i];
                 localResult[segmentIndex] = finalOffset;
             }
         }

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
@@ -58,7 +58,7 @@ std::vector<float> CompartmentData::getFrame(uint32_t frameIndex) const
     auto frame = frameFuture.get();
     auto &data = frame.data;
 
-    if (!data)
+    if (!data || data->empty())
     {
         throw std::runtime_error("Null report frame read");
     }

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
@@ -54,30 +54,35 @@ std::string CompartmentData::getTimeUnit() const noexcept
 
 std::vector<float> CompartmentData::getFrame(const uint32_t frameIndex) const
 {
-    const auto start = _report->getStartTime();
-    const auto end = _report->getEndTime();
-    const auto dt = _report->getTimestep();
-    const auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto start = _report->getStartTime();
+    auto end = _report->getEndTime();
+    auto dt = _report->getTimestep();
+    auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
 
     auto frameFuture = _report->loadFrame(frameTime);
     auto frame = frameFuture.get();
     auto &data = frame.data;
+
+    if (!data || data->empty())
+    {
+        throw std::runtime_error("Null report frame read");
+    }
 
     return *data;
 }
 
 std::vector<CellReportMapping> CompartmentData::computeMapping() const noexcept
 {
-    const auto &ccounts = _report->getCompartmentCounts();
-    const auto &offsets = _report->getOffsets();
+    auto &ccounts = _report->getCompartmentCounts();
+    auto &offsets = _report->getOffsets();
 
-    const auto &gids = _report->getGIDs();
+    auto &gids = _report->getGIDs();
     std::vector<CellReportMapping> mapping(gids.size());
 
     for (size_t i = 0; i < gids.size(); ++i)
     {
-        const auto &count = ccounts[i];
-        const auto &offset = offsets[i];
+        auto &count = ccounts[i];
+        auto &offset = offsets[i];
 
         auto &cellMapping = mapping[i];
         cellMapping.globalOffset = offset[0];

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
@@ -27,11 +27,6 @@ CompartmentData::CompartmentData(std::unique_ptr<brion::CompartmentReport> repor
 {
 }
 
-size_t CompartmentData::getFrameSize() const noexcept
-{
-    return _report->getFrameSize();
-}
-
 float CompartmentData::getStartTime() const noexcept
 {
     return _report->getStartTime();

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.cpp
@@ -47,7 +47,7 @@ std::string CompartmentData::getTimeUnit() const noexcept
     return _report->getTimeUnit();
 }
 
-std::vector<float> CompartmentData::getFrame(const uint32_t frameIndex) const
+std::vector<float> CompartmentData::getFrame(uint32_t frameIndex) const
 {
     auto start = _report->getStartTime();
     auto end = _report->getEndTime();
@@ -58,7 +58,7 @@ std::vector<float> CompartmentData::getFrame(const uint32_t frameIndex) const
     auto frame = frameFuture.get();
     auto &data = frame.data;
 
-    if (!data || data->empty())
+    if (!data)
     {
         throw std::runtime_error("Null report frame read");
     }
@@ -72,21 +72,23 @@ std::vector<CellReportMapping> CompartmentData::computeMapping() const noexcept
     auto &offsets = _report->getOffsets();
 
     auto &gids = _report->getGIDs();
-    std::vector<CellReportMapping> mapping(gids.size());
+    auto mapping = std::vector<CellReportMapping>();
+    mapping.reserve(gids.size());
 
     for (size_t i = 0; i < gids.size(); ++i)
     {
         auto &count = ccounts[i];
         auto &offset = offsets[i];
 
-        auto &cellMapping = mapping[i];
+        auto &cellMapping = mapping.emplace_back();
+
         cellMapping.globalOffset = offset[0];
         cellMapping.compartments = std::vector<uint16_t>(count.begin(), count.end());
-        cellMapping.offsets.resize(offset.size());
+        cellMapping.offsets.reserve(offset.size());
 
         for (size_t j = 0; j < offset.size(); ++j)
         {
-            cellMapping.offsets[j] = offset[j] - cellMapping.globalOffset;
+            cellMapping.offsets.push_back(offset[j] - cellMapping.globalOffset);
         }
     }
 

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.h
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.h
@@ -30,16 +30,10 @@ class CompartmentData : public IReportData
 public:
     CompartmentData(std::unique_ptr<brion::CompartmentReport> report);
 
-    size_t getFrameSize() const noexcept override;
-
     float getStartTime() const noexcept override;
-
     float getEndTime() const noexcept override;
-
     float getTimeStep() const noexcept override;
-
     std::string getTimeUnit() const noexcept override;
-
     std::vector<float> getFrame(const uint32_t frameIndex) const override;
 
     /**

--- a/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.h
+++ b/plugins/CircuitExplorer/io/bbploader/reports/CompartmentData.h
@@ -34,7 +34,7 @@ public:
     float getEndTime() const noexcept override;
     float getTimeStep() const noexcept override;
     std::string getTimeUnit() const noexcept override;
-    std::vector<float> getFrame(const uint32_t frameIndex) const override;
+    std::vector<float> getFrame(uint32_t frameIndex) const override;
 
     /**
      * @brief Computes and returns the report mapping
@@ -44,6 +44,6 @@ public:
     std::vector<CellReportMapping> computeMapping() const noexcept;
 
 private:
-    const std::unique_ptr<brion::CompartmentReport> _report;
+    std::unique_ptr<brion::CompartmentReport> _report;
 };
 }

--- a/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.cpp
@@ -33,11 +33,6 @@ SpikeData::SpikeData(
 {
 }
 
-size_t SpikeData::getFrameSize() const noexcept
-{
-    return _mapping.size();
-}
-
 float SpikeData::getStartTime() const noexcept
 {
     return 0.f;

--- a/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.cpp
+++ b/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.cpp
@@ -53,31 +53,32 @@ std::string SpikeData::getTimeUnit() const noexcept
     return "";
 }
 
-std::vector<float> SpikeData::getFrame(const uint32_t frameIndex) const
+std::vector<float> SpikeData::getFrame(uint32_t frameIndex) const
 {
-    std::vector<float> values(_mapping.size(), 0.f);
+    auto values = std::vector<float>(_mapping.size(), 0.f);
 
-    const auto start = getStartTime();
-    const auto end = getEndTime();
-    const auto dt = getTimeStep();
-    const auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
-    const auto frameStart = frameTime - _interval;
-    const auto frameEnd = frameTime + _interval;
+    auto start = getStartTime();
+    auto end = getEndTime();
+    auto dt = getTimeStep();
+    auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto frameStart = frameTime - _interval;
+    auto frameEnd = frameTime + _interval;
 
-    const auto spikes = _report->getSpikes(frameStart, frameEnd);
+    auto spikes = _report->getSpikes(frameStart, frameEnd);
 
     for (size_t i = 0; i < spikes.size(); ++i)
     {
-        const auto &spike = spikes[i];
-        const auto gid = spike.second;
-        const auto it = _mapping.find(gid);
+        auto &spike = spikes[i];
+        auto gid = spike.second;
+
+        auto it = _mapping.find(gid);
         if (it == _mapping.end())
         {
             continue;
         }
 
-        const auto index = it->second;
-        const auto spikeTime = spike.first;
+        auto index = it->second;
+        auto spikeTime = spike.first;
 
         values[index] = _spikeCalculator.compute(spikeTime, frameTime);
     }

--- a/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.h
+++ b/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.h
@@ -34,12 +34,12 @@ public:
     float getEndTime() const noexcept override;
     float getTimeStep() const noexcept override;
     std::string getTimeUnit() const noexcept override;
-    std::vector<float> getFrame(const uint32_t frameIndex) const override;
+    std::vector<float> getFrame(uint32_t frameIndex) const override;
 
 private:
-    const std::unique_ptr<brain::SpikeReportReader> _report;
-    const SpikeCalculator _spikeCalculator;
-    const float _interval{};
-    const std::unordered_map<uint64_t, size_t> _mapping;
+    std::unique_ptr<brain::SpikeReportReader> _report;
+    SpikeCalculator _spikeCalculator;
+    float _interval{};
+    std::unordered_map<uint64_t, size_t> _mapping;
 };
 }

--- a/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.h
+++ b/plugins/CircuitExplorer/io/bbploader/reports/SpikeData.h
@@ -30,16 +30,10 @@ class SpikeData : public IReportData
 public:
     SpikeData(std::unique_ptr<brain::SpikeReportReader> report, const std::vector<uint64_t> &gids, float spikeInterval);
 
-    size_t getFrameSize() const noexcept override;
-
     float getStartTime() const noexcept override;
-
     float getEndTime() const noexcept override;
-
     float getTimeStep() const noexcept override;
-
     std::string getTimeUnit() const noexcept override;
-
     std::vector<float> getFrame(const uint32_t frameIndex) const override;
 
 private:

--- a/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.cpp
@@ -20,11 +20,6 @@
 
 #include "SimulationMapping.h"
 
-#include <highfive/H5File.hpp>
-
-#include <unordered_map>
-#include <vector>
-
 namespace sonataloader
 {
 std::vector<bbp::sonata::NodeID> SimulationMapping::getCompartmentNodes(

--- a/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.cpp
@@ -25,94 +25,25 @@
 #include <unordered_map>
 #include <vector>
 
-namespace
-{
-using Range = std::pair<uint64_t, uint64_t>;
-using Mapping = std::pair<bbp::sonata::NodeID, bbp::sonata::ElementID>;
-
-class MappingComputer
-{
-public:
-    static std::vector<Mapping> compute(
-        const HighFive::Group &reportPop,
-        const std::unordered_map<bbp::sonata::NodeID, Range> &nodePointers,
-        const std::vector<bbp::sonata::NodeID> &nodeIds)
-    {
-        auto result = std::vector<Mapping>();
-        auto elementIdsData = reportPop.getGroup("mapping").getDataSet("element_ids");
-        for (auto nodeId : nodeIds)
-        {
-            auto it = nodePointers.find(nodeId);
-            if (it == nodePointers.end())
-            {
-                continue;
-            }
-
-            auto elementIds = std::vector<bbp::sonata::ElementID>(it->second.second - it->second.first);
-            elementIdsData.select({it->second.first}, {it->second.second - it->second.first}).read(elementIds.data());
-
-            for (auto elem : elementIds)
-            {
-                result.push_back(std::make_pair(nodeId, elem));
-            }
-        }
-        return result;
-    }
-};
-} // namespace
-
 namespace sonataloader
 {
 std::vector<bbp::sonata::NodeID> SimulationMapping::getCompartmentNodes(
     const std::string &reportPath,
     const std::string &population)
 {
-    const HighFive::File file(reportPath, HighFive::File::ReadOnly);
-    const auto reportPop = file.getGroup("/report/" + population);
-
-    std::vector<bbp::sonata::NodeID> reportNodeIds;
-    const auto mappingGroup = reportPop.getGroup("mapping");
-    mappingGroup.getDataSet("node_ids").read(reportNodeIds);
-    return reportNodeIds;
+    auto report = bbp::sonata::ElementReportReader(reportPath);
+    auto &reportPopulation = report.openPopulation(population);
+    return reportPopulation.getNodeIds();
 }
 
-// Extracted and optimized code
-// from https://github.com/BlueBrain/libsonata/blob/master/src/report_reader.cpp
-std::vector<Mapping> SimulationMapping::getCompartmentMapping(
+std::vector<bbp::sonata::CompartmentID> SimulationMapping::getCompartmentMapping(
     const std::string &reportPath,
     const std::string &population,
     const std::vector<bbp::sonata::NodeID> &nodeIds)
 {
-    // Get report population
-    const HighFive::File file(reportPath, HighFive::File::ReadOnly);
-    const auto reportPop = file.getGroup("/report/" + population);
-
-    // Get reported node Ids
-    std::vector<bbp::sonata::NodeID> reportNodeIds;
-    const auto mappingGroup = reportPop.getGroup("mapping");
-    mappingGroup.getDataSet("node_ids").read(reportNodeIds);
-
-    // Get indices
-    std::vector<uint64_t> indexPointers;
-    mappingGroup.getDataSet("index_pointers").read(indexPointers);
-
-    // Create node pointers to know how to access the mapping dataset
-
-    std::unordered_map<bbp::sonata::NodeID, Range> nodePointers;
-    for (size_t i = 0; i < reportNodeIds.size(); ++i)
-    {
-        const auto nodeId = reportNodeIds[i];
-        const auto start = indexPointers[i];
-        const auto end = indexPointers[i + 1];
-
-        nodePointers.emplace(nodeId, std::make_pair(start, end));
-    }
-
-    if (!nodeIds.empty())
-    {
-        return MappingComputer::compute(reportPop, nodePointers, nodeIds);
-    }
-
-    return MappingComputer::compute(reportPop, nodePointers, reportNodeIds);
+    auto report = bbp::sonata::ElementReportReader(reportPath);
+    auto &reportPopulation = report.openPopulation(population);
+    auto selection = bbp::sonata::Selection::fromValues(nodeIds);
+    return reportPopulation.getNodeIdElementIdMapping(selection);
 }
 } // namespace sonataloader

--- a/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.h
+++ b/plugins/CircuitExplorer/io/sonataloader/data/SimulationMapping.h
@@ -46,7 +46,7 @@ public:
      * once, denoting that the given element of the given node has multiple
      * compartments reported.
      */
-    static std::vector<std::pair<bbp::sonata::NodeID, bbp::sonata::ElementID>> getCompartmentMapping(
+    static std::vector<bbp::sonata::CompartmentID> getCompartmentMapping(
         const std::string &reportPath,
         const std::string &population,
         const std::vector<bbp::sonata::NodeID> &nodeIds);

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/VasculaturePopulationLoader.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/VasculaturePopulationLoader.cpp
@@ -129,7 +129,7 @@ private:
         auto sortedCompartments = std::map<uint64_t, size_t>();
         for (size_t i = 0; i < rawMapping.size(); ++i)
         {
-            sortedCompartments[rawMapping[i].first] = i;
+            sortedCompartments[rawMapping[i][0]] = i;
         }
 
         auto offsets = std::vector<size_t>(sortedCompartments.size());

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
@@ -26,9 +26,6 @@
 #include <io/sonataloader/reports/SonataReportData.h>
 #include <io/sonataloader/reports/SonataSpikeData.h>
 
-#include <brayns/utils/Log.h>
-#include <brayns/utils/Timer.h>
-
 namespace
 {
 namespace sl = sonataloader;
@@ -36,77 +33,11 @@ namespace sl = sonataloader;
 class SonataCompartmentMapping
 {
 public:
-    /*
-        static std::vector<CellReportMapping>
-            generate(const std::string &path, const std::string &population, const std::vector<uint64_t> &nodeList)
-        {
-            brayns::Log::critical("BEGIN");
-            auto timer = brayns::Timer();
-
-            timer.reset();
-            auto rawMapping = sl::SimulationMapping::getCompartmentMapping(path, population, nodeList);
-            brayns::Log::critical("READ {}", timer.seconds());
-
-            // Compact mapping
-            timer.reset();
-            auto sortedCompartmentsSize = std::map<uint64_t, std::vector<uint16_t>>();
-            auto lastSection = std::numeric_limits<uint32_t>::max();
-            auto lastNode = std::numeric_limits<uint64_t>::max();
-
-            for (auto &key : rawMapping)
-            {
-                auto nodeId = key[0];
-                auto elementId = key[1];
-                auto &cm = sortedCompartmentsSize[nodeId];
-                if (lastSection != elementId || lastNode != nodeId)
-                {
-                    lastNode = nodeId;
-                    lastSection = elementId;
-                    cm.push_back(0u);
-                }
-                cm[elementId]++;
-            }
-            brayns::Log::critical("SIZES {}", timer.seconds());
-
-            // Returns a node id sorted list of compartment mappings
-            timer.reset();
-            auto mapping = std::vector<CellReportMapping>(sortedCompartmentsSize.size());
-            // Transform into brayns mapping
-            auto it = sortedCompartmentsSize.begin();
-            auto index = 0ul;
-            auto prevOffset = 0ul;
-            for (; it != sortedCompartmentsSize.end(); ++it)
-            {
-                auto &cellMapping = mapping[index];
-                cellMapping.globalOffset = prevOffset;
-                cellMapping.compartments.resize(it->second.size());
-                cellMapping.offsets.resize(it->second.size());
-
-                uint16_t localOffset = 0;
-                for (size_t i = 0; i < it->second.size(); ++i)
-                {
-                    const auto sectionCompartments = it->second[i];
-                    cellMapping.offsets[i] = localOffset;
-                    cellMapping.compartments[i] = sectionCompartments;
-                    localOffset += sectionCompartments;
-                    prevOffset += sectionCompartments;
-                }
-
-                ++index;
-            }
-            brayns::Log::critical("MAPPINGS {}", timer.seconds());
-
-            return mapping;
-        }
-    */
     static std::vector<CellReportMapping>
         generate(const std::string &path, const std::string &population, const std::vector<uint64_t> &nodeList)
     {
-        brayns::Log::critical("BEGIN REPORT LOADING");
-
         auto compartmentsSize = _computeCompartmentsSize(path, population, nodeList);
 
-        auto timer = brayns::Timer();
         auto mapping = std::vector<CellReportMapping>();
         mapping.reserve(compartmentsSize.size());
 
@@ -132,7 +63,6 @@ public:
 
             prevOffset += localOffset;
         }
-        brayns::Log::critical("MAPPINGS {}", timer.seconds());
 
         return mapping;
     }
@@ -153,17 +83,9 @@ private:
         const std::string &population,
         const std::vector<uint64_t> &nodeList)
     {
-        auto timer = brayns::Timer();
-
-        timer.reset();
         auto compartments = sl::SimulationMapping::getCompartmentMapping(reportPath, population, nodeList);
-        brayns::Log::critical("READ {}", timer.seconds());
-
-        timer.reset();
         auto indexer = _createIndexer(nodeList);
-        brayns::Log::critical("INDEXER CREATION {}", timer.seconds());
 
-        timer.reset();
         auto compartmentsSize = std::vector<std::vector<uint16_t>>(nodeList.size());
         auto lastSection = std::numeric_limits<uint32_t>::max();
         auto lastNode = std::numeric_limits<uint64_t>::max();
@@ -183,7 +105,6 @@ private:
             }
             cm[elementId]++;
         }
-        brayns::Log::critical("SIZES {}", timer.seconds());
 
         return compartmentsSize;
     }

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
@@ -37,26 +37,72 @@ class SonataCompartmentMapping
 {
 public:
     static std::vector<CellReportMapping>
-        generate(const std::string &reportPath, const std::string &population, const std::vector<uint64_t> &nodeList)
+        generate(const std::string &path, const std::string &population, const std::vector<uint64_t> &nodeList)
     {
-        brayns::Log::critical("BEGIN");
-        auto timer = brayns::Timer();
+        auto compartmentsSizes = _computeCompartmentsSize(path, population, nodeList);
 
-        timer.reset();
-        auto rawMapping = sl::SimulationMapping::getCompartmentMapping(reportPath, population, nodeList);
-        brayns::Log::critical("READ {}", timer.seconds());
+        auto mapping = std::vector<CellReportMapping>();
+        mapping.reserve(compartmentsSizes.size());
 
-        // Compact mapping
-        timer.reset();
-        auto sortedCompartmentsSize = std::map<uint64_t, std::vector<uint16_t>>();
-        auto lastSection = std::numeric_limits<uint32_t>::max();
-        auto lastNode = std::numeric_limits<uint64_t>::max();
+        auto prevOffset = 0ul;
 
-        for (auto &key : rawMapping)
+        for (auto &compartmentSize : compartmentsSizes)
+        {
+            auto &cellMapping = mapping.emplace_back();
+
+            cellMapping.globalOffset = prevOffset;
+
+            auto &compartments = cellMapping.compartments;
+            compartments.resize(compartmentSize.size());
+
+            auto &offsets = cellMapping.offsets;
+            offsets.resize(compartmentSize.size());
+
+            uint16_t localOffset = 0;
+            for (size_t i = 0; i < compartmentSize.size(); ++i)
+            {
+                auto size = compartmentSize[i];
+                compartments[i] = size;
+                offsets[i] = localOffset;
+                localOffset += size;
+            }
+
+            prevOffset += localOffset;
+        }
+        brayns::Log::critical("MAPPINGS {}", timer.seconds());
+
+        return mapping;
+    }
+
+private:
+    static std::vector<size_t> _createIndexer(const std::vector<uint64_t> &nodeList)
+    {
+        auto indexer = std::vector<size_t>(nodeList.back() + 1, std::numeric_limits<size_t>::max());
+        for (size_t i = 0; i < nodeList.size(); ++i)
+        {
+            indexer[nodeList[i]] = i;
+        }
+        return indexer;
+    }
+
+    static std::vector<std::vector<uint16_t>> _computeCompartmentsSize(
+        const std::string &reportPath,
+        const std::string &population,
+        const std::vector<uint64_t> &nodeList)
+    {
+        auto compartments = sl::SimulationMapping::getCompartmentMapping(reportPath, population, nodeList);
+        auto indexer = _createIndexer(nodeList);
+        auto compartmentsSize = std::vector<std::vector<uint16_t>>(nodeList.size());
+
+        uint32_t lastSection = std::numeric_limits<uint32_t>::max();
+        uint64_t lastNode = std::numeric_limits<uint64_t>::max();
+        for (auto &key : compartments)
         {
             auto nodeId = key[0];
             auto elementId = key[1];
-            auto &cm = sortedCompartmentsSize[nodeId];
+
+            auto index = indexer[nodeId];
+            auto &cm = compartmentsSize[index];
             if (lastSection != elementId || lastNode != nodeId)
             {
                 lastNode = nodeId;
@@ -65,37 +111,8 @@ public:
             }
             cm[elementId]++;
         }
-        brayns::Log::critical("SIZES {}", timer.seconds());
 
-        // Returns a node id sorted list of compartment mappings
-        timer.reset();
-        auto mapping = std::vector<CellReportMapping>(sortedCompartmentsSize.size());
-        // Transform into brayns mapping
-        auto it = sortedCompartmentsSize.begin();
-        auto index = 0ul;
-        auto prevOffset = 0ul;
-        for (; it != sortedCompartmentsSize.end(); ++it)
-        {
-            auto &cellMapping = mapping[index];
-            cellMapping.globalOffset = prevOffset;
-            cellMapping.compartments.resize(it->second.size());
-            cellMapping.offsets.resize(it->second.size());
-
-            uint16_t localOffset = 0;
-            for (size_t i = 0; i < it->second.size(); ++i)
-            {
-                const auto sectionCompartments = it->second[i];
-                cellMapping.offsets[i] = localOffset;
-                cellMapping.compartments[i] = sectionCompartments;
-                localOffset += sectionCompartments;
-                prevOffset += sectionCompartments;
-            }
-
-            ++index;
-        }
-        brayns::Log::critical("MAPPINGS {}", timer.seconds());
-
-        return mapping;
+        return compartmentsSize;
     }
 };
 

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/NeuronReportFactory.cpp
@@ -165,9 +165,9 @@ private:
 
         timer.reset();
         auto compartmentsSize = std::vector<std::vector<uint16_t>>(nodeList.size());
+        auto lastSection = std::numeric_limits<uint32_t>::max();
+        auto lastNode = std::numeric_limits<uint64_t>::max();
 
-        uint32_t lastSection = std::numeric_limits<uint32_t>::max();
-        uint64_t lastNode = std::numeric_limits<uint64_t>::max();
         for (auto &key : compartments)
         {
             auto nodeId = key[0];

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.cpp
@@ -25,9 +25,6 @@
 #include <io/sonataloader/data/Cells.h>
 #include <io/sonataloader/populations/nodes/common/NeuronReportFactory.h>
 
-#include <brayns/utils/Log.h>
-#include <brayns/utils/Timer.h>
-
 namespace sonataloader
 {
 void SomaImporter::import(NodeLoadContext &context)
@@ -38,26 +35,18 @@ void SomaImporter::import(NodeLoadContext &context)
     auto &selection = context.selection;
     auto ids = selection.flatten();
 
-    brayns::Log::critical("BEGIN LOAD");
-    auto timer = brayns::Timer();
+    auto colorData = ColorDataFactory::create(context);
 
-    timer.reset();
     auto positions = Cells::getPositions(population, selection);
-    brayns::Log::critical("POSITION READ {}", timer.seconds());
 
     auto &params = context.params;
     auto &neuronParams = params.neuron_morphology_parameters;
     auto radiusMultiplier = neuronParams.radius_multiplier;
 
-    auto buildContext = SomaCircuitBuilder::Context{
-        std::move(ids),
-        std::move(positions),
-        ColorDataFactory::create(context),
-        radiusMultiplier};
+    auto buildContext =
+        SomaCircuitBuilder::Context{std::move(ids), std::move(positions), std::move(colorData), radiusMultiplier};
 
-    timer.reset();
     auto compartments = SomaCircuitBuilder::build(context.model, std::move(buildContext));
-    brayns::Log::critical("SOMA BUILD {}", timer.seconds());
     NeuronReportFactory::create(context, compartments);
 }
 }

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.cpp
@@ -25,6 +25,9 @@
 #include <io/sonataloader/data/Cells.h>
 #include <io/sonataloader/populations/nodes/common/NeuronReportFactory.h>
 
+#include <brayns/utils/Log.h>
+#include <brayns/utils/Timer.h>
+
 namespace sonataloader
 {
 void SomaImporter::import(NodeLoadContext &context)
@@ -35,7 +38,12 @@ void SomaImporter::import(NodeLoadContext &context)
     auto &selection = context.selection;
     auto ids = selection.flatten();
 
+    brayns::Log::critical("BEGIN LOAD");
+    auto timer = brayns::Timer();
+
+    timer.reset();
     auto positions = Cells::getPositions(population, selection);
+    brayns::Log::critical("POSITION READ {}", timer.seconds());
 
     auto &params = context.params;
     auto &neuronParams = params.neuron_morphology_parameters;
@@ -47,7 +55,9 @@ void SomaImporter::import(NodeLoadContext &context)
         ColorDataFactory::create(context),
         radiusMultiplier};
 
+    timer.reset();
     auto compartments = SomaCircuitBuilder::build(context.model, std::move(buildContext));
+    brayns::Log::critical("SOMA BUILD {}", timer.seconds());
     NeuronReportFactory::create(context, compartments);
 }
 }

--- a/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.h
+++ b/plugins/CircuitExplorer/io/sonataloader/populations/nodes/common/SomaImporter.h
@@ -16,14 +16,15 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <io/sonataloader/LoadContext.h>
-
 #pragma once
+
+#include <io/sonataloader/LoadContext.h>
 
 namespace sonataloader
 {
-struct SomaImporter
+class SomaImporter
 {
+public:
     static void import(NodeLoadContext &nodeContext);
 };
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -59,12 +59,12 @@ std::string SonataReportData::getTimeUnit() const noexcept
 std::vector<float> SonataReportData::getFrame(const uint32_t frameIndex) const
 {
     auto [start, end, dt] = _population.getTimes();
-    auto start = FrameTimeCalculator::compute(frameIndex, start, end, dt);
-    auto end = start + dt;
+    auto startTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto endTime = start + dt;
     auto frame = _population.get(
         nonstd::optional<bbp::sonata::Selection>(_selection),
-        nonstd::optional<double>(start),
-        nonstd::optional<double>(end));
+        nonstd::optional<double>(startTime),
+        nonstd::optional<double>(endTime));
 
     return frame.data;
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -20,6 +20,11 @@
 
 #include <api/reports/common/FrameTimeCalculator.h>
 
+namespace
+{
+inline static constexpr double sonataEspsilon = 1e-6;
+}
+
 namespace sonataloader
 {
 SonataReportData::SonataReportData(
@@ -56,15 +61,12 @@ std::string SonataReportData::getTimeUnit() const noexcept
     return _population.getTimeUnits();
 }
 
-std::vector<float> SonataReportData::getFrame(const uint32_t frameIndex) const
+std::vector<float> SonataReportData::getFrame(uint32_t frameIndex) const
 {
     auto [start, end, dt] = _population.getTimes();
-    auto startTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto startTime = FrameTimeCalculator::compute(frameIndex, start, end, dt) - sonataEspsilon;
     auto endTime = startTime + dt;
-    auto frame = _population.get(
-        nonstd::optional<bbp::sonata::Selection>(_selection),
-        nonstd::optional<double>(startTime),
-        nonstd::optional<double>(endTime));
+    auto frame = _population.get(_selection, startTime, endTime);
 
     return frame.data;
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -68,6 +68,11 @@ std::vector<float> SonataReportData::getFrame(uint32_t frameIndex) const
     auto endTime = startTime + dt;
     auto frame = _population.get(_selection, startTime, endTime);
 
+    if (frame.data.empty())
+    {
+        throw std::runtime_error("Emtpy frame read");
+    }
+
     return frame.data;
 }
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -30,17 +30,10 @@ SonataReportData::SonataReportData(
     , _population(_reader.openPopulation(population))
     , _selection(std::move(selection))
 {
-    const auto [start, end, dt] = _population.getTimes();
+    auto [start, end, dt] = _population.getTimes();
     _start = start;
     _end = end;
     _dt = dt;
-    const auto firstFrame = getFrame(0);
-    _frameSize = firstFrame.size();
-}
-
-size_t SonataReportData::getFrameSize() const noexcept
-{
-    return _frameSize;
 }
 
 float SonataReportData::getStartTime() const noexcept

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -60,7 +60,7 @@ std::vector<float> SonataReportData::getFrame(const uint32_t frameIndex) const
 {
     auto [start, end, dt] = _population.getTimes();
     auto startTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
-    auto endTime = start + dt;
+    auto endTime = startTime + dt;
     auto frame = _population.get(
         nonstd::optional<bbp::sonata::Selection>(_selection),
         nonstd::optional<double>(startTime),

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.cpp
@@ -58,13 +58,13 @@ std::string SonataReportData::getTimeUnit() const noexcept
 
 std::vector<float> SonataReportData::getFrame(const uint32_t frameIndex) const
 {
-    const auto [start, end, dt] = _population.getTimes();
-    const auto timestamp = FrameTimeCalculator::compute(frameIndex, start, end, dt);
-    const auto frame = _population.get(
+    auto [start, end, dt] = _population.getTimes();
+    auto start = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto end = start + dt;
+    auto frame = _population.get(
         nonstd::optional<bbp::sonata::Selection>(_selection),
-        nonstd::optional<double>(timestamp),
-        nonstd::nullopt,
-        nonstd::nullopt);
+        nonstd::optional<double>(start),
+        nonstd::optional<double>(end));
 
     return frame.data;
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.h
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.h
@@ -29,16 +29,10 @@ class SonataReportData final : public IReportData
 public:
     SonataReportData(const std::string &reportPath, const std::string &population, bbp::sonata::Selection selection);
 
-    size_t getFrameSize() const noexcept override;
-
     float getStartTime() const noexcept override;
-
     float getEndTime() const noexcept override;
-
     float getTimeStep() const noexcept override;
-
     std::string getTimeUnit() const noexcept override;
-
     std::vector<float> getFrame(const uint32_t frameIndex) const override;
 
 private:
@@ -48,6 +42,5 @@ private:
     float _start{};
     float _end{};
     float _dt{};
-    size_t _frameSize{};
 };
 }

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.h
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataReportData.h
@@ -33,7 +33,7 @@ public:
     float getEndTime() const noexcept override;
     float getTimeStep() const noexcept override;
     std::string getTimeUnit() const noexcept override;
-    std::vector<float> getFrame(const uint32_t frameIndex) const override;
+    std::vector<float> getFrame(uint32_t frameIndex) const override;
 
 private:
     const bbp::sonata::ElementReportReader _reader;

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.cpp
@@ -40,11 +40,6 @@ SonataSpikeData::SonataSpikeData(
     _end = end;
 }
 
-size_t SonataSpikeData::getFrameSize() const noexcept
-{
-    return _mapping.size();
-}
-
 float SonataSpikeData::getStartTime() const noexcept
 {
     return _start;
@@ -67,7 +62,7 @@ std::string SonataSpikeData::getTimeUnit() const noexcept
 
 std::vector<float> SonataSpikeData::getFrame(const uint32_t frameIndex) const
 {
-    std::vector<float> data(getFrameSize(), 0.f);
+    std::vector<float> data(_mapping.size(), 0.f);
 
     const auto start = getStartTime();
     const auto end = getEndTime();

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.cpp
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.cpp
@@ -35,7 +35,7 @@ SonataSpikeData::SonataSpikeData(
     , _calculator(interval)
     , _interval(interval)
 {
-    const auto [start, end] = _population.getTimes();
+    auto [start, end] = _population.getTimes();
     _start = start;
     _end = end;
 }
@@ -60,34 +60,32 @@ std::string SonataSpikeData::getTimeUnit() const noexcept
     return "";
 }
 
-std::vector<float> SonataSpikeData::getFrame(const uint32_t frameIndex) const
+std::vector<float> SonataSpikeData::getFrame(uint32_t frameIndex) const
 {
-    std::vector<float> data(_mapping.size(), 0.f);
+    auto data = std::vector<float>(_mapping.size(), 0.f);
 
-    const auto start = getStartTime();
-    const auto end = getEndTime();
-    const auto dt = getTimeStep();
-    const auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
-    const auto frameStart = frameTime - _interval;
-    const auto frameEnd = frameTime + _interval;
+    auto start = getStartTime();
+    auto end = getEndTime();
+    auto dt = getTimeStep();
+    auto frameTime = FrameTimeCalculator::compute(frameIndex, start, end, dt);
+    auto frameStart = frameTime - _interval;
+    auto frameEnd = frameTime + _interval;
 
-    const auto spikes = _population.get(
-        nonstd::optional<bbp::sonata::Selection>(_selection),
-        nonstd::optional<double>(frameStart),
-        nonstd::optional<double>(frameEnd));
+    auto spikes = _population.get(_selection, frameStart, frameEnd);
 
     for (size_t i = 0; i < spikes.size(); ++i)
     {
-        const auto &spike = spikes[i];
-        const auto nodeId = spike.first;
-        const auto spikeTime = spike.second;
-        const auto it = _mapping.find(nodeId);
+        auto &spike = spikes[i];
+        auto nodeId = spike.first;
+        auto spikeTime = spike.second;
+        auto it = _mapping.find(nodeId);
+
         if (it == _mapping.end())
         {
             continue;
         }
-        const auto index = it->second;
 
+        auto index = it->second;
         data[index] = _calculator.compute(spikeTime, frameTime);
     }
 

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.h
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.h
@@ -35,14 +35,10 @@ public:
         float interval);
 
     float getStartTime() const noexcept override;
-
     float getEndTime() const noexcept override;
-
     float getTimeStep() const noexcept override;
-
     std::string getTimeUnit() const noexcept override;
-
-    std::vector<float> getFrame(const uint32_t frameIndex) const override;
+    std::vector<float> getFrame(uint32_t frameIndex) const override;
 
 private:
     const bbp::sonata::SpikeReader _reader;
@@ -50,7 +46,7 @@ private:
     const bbp::sonata::Selection _selection;
     const std::unordered_map<uint64_t, size_t> _mapping;
     const SpikeCalculator _calculator;
-    const float _interval{};
+    float _interval{};
     float _start{};
     float _end{};
 };

--- a/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.h
+++ b/plugins/CircuitExplorer/io/sonataloader/reports/SonataSpikeData.h
@@ -34,8 +34,6 @@ public:
         bbp::sonata::Selection selection,
         float interval);
 
-    size_t getFrameSize() const noexcept override;
-
     float getStartTime() const noexcept override;
 
     float getEndTime() const noexcept override;

--- a/plugins/CircuitExplorer/systems/ReportSystem.cpp
+++ b/plugins/CircuitExplorer/systems/ReportSystem.cpp
@@ -28,9 +28,6 @@
 #include <components/ColorHandler.h>
 #include <components/ReportData.h>
 
-#include <brayns/utils/Log.h>
-#include <brayns/utils/Timer.h>
-
 bool ReportSystem::isEnabled(brayns::Components &components)
 {
     auto &info = components.get<brayns::SimulationInfo>();
@@ -59,31 +56,18 @@ bool ReportSystem::shouldExecute(brayns::Components &components)
 
 void ReportSystem::execute(brayns::Components &components, uint32_t frame)
 {
-    auto timer = brayns::Timer();
-
     auto &colorRamp = components.get<brayns::ColorRamp>();
     auto &colorMap = components.getOrAdd<brayns::ColorMap>();
 
-    timer.reset();
     colorMap.colors = ColorRampUtils::createSampleBuffer(colorRamp);
-    brayns::Log::critical("COLOR BUFFER {}", timer.seconds());
-
     auto &range = colorRamp.getValuesRange();
 
     auto &report = components.get<ReportData>();
-    timer.reset();
     auto frameData = report.data->getFrame(frame);
-    brayns::Log::critical("FRAME READ {}", timer.seconds());
-
-    timer.reset();
     colorMap.indices = report.indexer->generate(frameData, range);
-    brayns::Log::critical("INDEXING {}", timer.seconds());
 
     auto &painter = *components.get<ColorHandler>().handler;
     auto &geometries = components.get<brayns::Geometries>();
     auto &views = components.get<brayns::GeometryViews>();
-
-    timer.reset();
     painter.colorByColormap(colorMap, geometries, views);
-    brayns::Log::critical("PAINTING {}", timer.seconds());
 }

--- a/plugins/CircuitExplorer/systems/ReportSystem.cpp
+++ b/plugins/CircuitExplorer/systems/ReportSystem.cpp
@@ -28,6 +28,9 @@
 #include <components/ColorHandler.h>
 #include <components/ReportData.h>
 
+#include <brayns/utils/Log.h>
+#include <brayns/utils/Timer.h>
+
 bool ReportSystem::isEnabled(brayns::Components &components)
 {
     auto &info = components.get<brayns::SimulationInfo>();
@@ -56,19 +59,31 @@ bool ReportSystem::shouldExecute(brayns::Components &components)
 
 void ReportSystem::execute(brayns::Components &components, uint32_t frame)
 {
+    auto timer = brayns::Timer();
+
     auto &colorRamp = components.get<brayns::ColorRamp>();
     auto &colorMap = components.getOrAdd<brayns::ColorMap>();
 
+    timer.reset();
     colorMap.colors = ColorRampUtils::createSampleBuffer(colorRamp);
+    brayns::Log::critical("COLOR BUFFER {}", timer.seconds());
+
     auto &range = colorRamp.getValuesRange();
 
     auto &report = components.get<ReportData>();
+    timer.reset();
     auto frameData = report.data->getFrame(frame);
+    brayns::Log::critical("FRAME READ {}", timer.seconds());
+
+    timer.reset();
     colorMap.indices = report.indexer->generate(frameData, range);
+    brayns::Log::critical("INDEXING {}", timer.seconds());
 
     auto &painter = *components.get<ColorHandler>().handler;
     auto &geometries = components.get<brayns::Geometries>();
     auto &views = components.get<brayns::GeometryViews>();
 
+    timer.reset();
     painter.colorByColormap(colorMap, geometries, views);
+    brayns::Log::critical("PAINTING {}", timer.seconds());
 }


### PR DESCRIPTION
- Removal of frameSize (legacy) which slowed down circuit loading with simulation
- Fixed retrival of SONATA report frames (it tried to load the whole report at once)
- Removed superflous omp parallelizations and uneeded pre-initializations
- Replaced custom code to retrieve report mapping by calls to libsonata