### PR TITLE
Fix header includes for GCC 12.

### DIFF
--- a/brayns/engine/model/systemtypes/ColorSystem.h
+++ b/brayns/engine/model/systemtypes/ColorSystem.h
@@ -24,6 +24,7 @@
 #include <brayns/utils/MathTypes.h>
 
 #include <unordered_map>
+#include <vector>
 
 namespace brayns
 {

--- a/brayns/utils/DynamicLib.cpp
+++ b/brayns/utils/DynamicLib.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <string>
+#include <utility> // std::exchange
 
 #include <dlfcn.h>
 #include <sys/times.h>

--- a/brayns/utils/string/StringExtractor.cpp
+++ b/brayns/utils/string/StringExtractor.cpp
@@ -22,6 +22,7 @@
 #include "StringExtractor.h"
 
 #include <algorithm>
+#include <utility> // std::exchange
 
 #include "StringInfo.h"
 #include "StringTrimmer.h"


### PR DESCRIPTION
These headers were probably implicitly included before, but no longer in GCC 12. Comment with the component used where not obvious. (Thanks @matz-e )