### PR TITLE
Include missing cstdint header, bump spdlog

### DIFF
--- a/brayns/utils/string/StringParser.h
+++ b/brayns/utils/string/StringParser.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 namespace brayns

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -63,7 +63,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/spdlog")
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog.git
-        GIT_TAG v1.12.0
+        GIT_TAG v1.15.0
         GIT_SHALLOW ON
         GIT_SUBMODULES_RECURSE ON
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spdlog

--- a/plugins/CircuitExplorer/api/coloring/IBrainColorData.h
+++ b/plugins/CircuitExplorer/api/coloring/IBrainColorData.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Noticed on Ubuntu 24 with GCC 13. spdlog needed to disambiguate some format issues.

Latest Spack builds clean with this PR applied.